### PR TITLE
fix pypy travis, cache pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
     - VECLIB_MAXIMUM_THREADS=1
     - EXTRAS=docs,matrix_scipy,matrix_mkl,export_mpl
     - PYTHON=python3
+cache: pip
 matrix:
   include:
     - name: "Python: 3.5"
@@ -23,16 +24,16 @@ matrix:
       python: "3.6"
       env:
         - EXTRAS=matrix_mkl,export_mpl
-        - FORCE_PYTHON_PKGS="numpy==1.12"
+        - CONSTRAINTS=numpy==1.12
     - name: "Pypy"
       os: linux
-      language: generic
+      python: pypy3.5
       env:
         - EXTRAS=matrix_mkl,export_mpl
+        - PYTHON=venv/bin/python3
       before_install:
         - wget --no-verbose -O - "$PYPY_URL" | tar xj
         - pypy*/bin/pypy3 -m venv venv
-        - . venv/bin/activate
     - name: "Python"
       os: osx
       language: generic
@@ -48,7 +49,11 @@ matrix:
       env:
         - PYTHON=/c/Python/python.exe
 install:
-  - $PYTHON -m pip install --upgrade .[$EXTRAS] coverage codecov $FORCE_PYTHON_PKGS
+  - $PYTHON -m pip install --upgrade pip wheel
+  - touch .constraints
+  - for CONSTRAINT in $CONSTRAINTS; do echo $CONSTRAINT >> .constraints; done
+  - $PYTHON -m pip install --upgrade --constraint .constraints numpy
+  - $PYTHON -m pip install --upgrade --constraint .constraints .[$EXTRAS] coverage codecov
 script:
   - $PYTHON -m coverage run -m unittest -b
 after_success:


### PR DESCRIPTION
Matplotlib has numpy as setup requirement. Pip defers installing packages until
all packages are built. When building matplotlib, numpy is not yet installed
and setuptools(?) downloads and builds a potentially different version of numpy
than pip has already downloaded. This patch makes sure numpy is installed
before matplotlib is being built.