### PR TITLE
Transforms updates

### DIFF
--- a/nutils/elementseq.py
+++ b/nutils/elementseq.py
@@ -133,6 +133,8 @@ class References(types.Singleton):
     if numeric.isint(other):
       if other == 0:
         return EmptyReferences(self.ndims)
+      elif other == 1:
+        return self
       else:
         return RepeatedReferences(self, other)
     elif isinstance(other, References):
@@ -416,6 +418,8 @@ class RepeatedReferences(References):
     if numeric.isint(other):
       if other == 0:
         return EmptyReferences(self.ndims)
+      elif other == 1:
+        return self
       else:
         return RepeatedReferences(self._parent, self._count*other)
     else:

--- a/nutils/mesh.py
+++ b/nutils/mesh.py
@@ -575,8 +575,9 @@ def simplex(nodes, cnodes, coords, tags, btags, ptags, name='simplex'):
     ptrans = [transform.Matrix(linear=numpy.zeros(shape=(ndims,0)), offset=offset) for offset in numpy.eye(ndims+1)[:,1:]]
     pmap = {inode: numpy.array(numpy.equal(nodes, inode).nonzero()).T for inode in set.union(*map(set, ptags.values()))}
     for pname, inodes in ptags.items():
-      ptransforms = [topo.transforms[ielem] + (ptrans[ivertex],) for inode in inodes for ielem, ivertex in pmap[inode]]
-      pgroups[pname] = topology.UnstructuredTopology((element.getsimplex(0),)*len(ptransforms), ptransforms, ptransforms, ndims=0)
+      ptransforms = transformseq.PlainTransforms([topo.transforms[ielem] + (ptrans[ivertex],) for inode in inodes for ielem, ivertex in pmap[inode]], 0)
+      preferences = elementseq.asreferences([element.getsimplex(0)], 0)*len(ptransforms)
+      pgroups[pname] = topology.Topology(preferences, ptransforms, ptransforms)
 
   vgroups = {}
   for name, ielems in tags.items():
@@ -618,8 +619,9 @@ def simplex(nodes, cnodes, coords, tags, btags, ptags, name='simplex'):
           groups[bname] = topology.SimplexTopology(simplices, transforms, opposites)
     vpgroups = {}
     for pname, inodes in ptags.items():
-      ptransforms = [topo.transforms[ielem] + (ptrans[ivertex],) for inode in inodes for ielem, ivertex in pmap[inode] if keep[ielem]]
-      vpgroups[pname] = topology.UnstructuredTopology((element.getsimplex(0),)*len(ptransforms), ptransforms, ptransforms, ndims=0)
+      ptransforms = transformseq.PlainTransforms([topo.transforms[ielem] + (ptrans[ivertex],) for inode in inodes for ielem, ivertex in pmap[inode] if keep[ielem]], 0)
+      preferences = elementseq.asreferences([element.getsimplex(0)], 0)*len(ptransforms)
+      vpgroups[pname] = topology.Topology(preferences, ptransforms, ptransforms)
     vgroups[name] = vtopo.withgroups(bgroups=vbgroups, igroups=vigroups, pgroups=vpgroups)
 
   return topo.withgroups(vgroups=vgroups, bgroups=bgroups, igroups=igroups, pgroups=pgroups), geom

--- a/nutils/topology.py
+++ b/nutils/topology.py
@@ -818,7 +818,7 @@ class EmptyTopology(Topology):
 
   @types.apply_annotations
   def __init__(self, ndims:types.strictint):
-    super().__init__(elementseq.PlainReferences((), ndims), transformseq.PlainTransforms((), ndims), transformseq.PlainTransforms((), ndims))
+    super().__init__(elementseq.EmptyReferences(ndims), transformseq.PlainTransforms((), ndims), transformseq.PlainTransforms((), ndims))
 
   def __or__(self, other):
     assert self.ndims == other.ndims

--- a/nutils/topology.py
+++ b/nutils/topology.py
@@ -818,7 +818,7 @@ class EmptyTopology(Topology):
 
   @types.apply_annotations
   def __init__(self, ndims:types.strictint):
-    super().__init__(elementseq.EmptyReferences(ndims), transformseq.PlainTransforms((), ndims), transformseq.PlainTransforms((), ndims))
+    super().__init__(elementseq.EmptyReferences(ndims), transformseq.EmptyTransforms(ndims), transformseq.EmptyTransforms(ndims))
 
   def __or__(self, other):
     assert self.ndims == other.ndims

--- a/nutils/transformseq.py
+++ b/nutils/transformseq.py
@@ -272,6 +272,27 @@ class Transforms(types.Singleton):
     else:
       return DerivedTransforms(self, references, 'child_transforms', self.fromdims)
 
+  def edges(self, references):
+    '''Return the sequence of edge transforms given ``references``.
+
+    Parameters
+    ----------
+    references : :class:`~nutils.elementseq.References`
+        A sequence of references matching this sequence of transforms.
+
+    Returns
+    -------
+    :class:`Transforms`
+        The sequence of edge transforms::
+
+            (trans+(etrans,) for trans, ref in zip(self, references) for etrans in ref.edge_transforms)
+    '''
+
+    if references.isuniform:
+      return UniformDerivedTransforms(self, references[0], 'edge_transforms', self.fromdims-1)
+    else:
+      return DerivedTransforms(self, references, 'edge_transforms', self.fromdims-1)
+
   def __add__(self, other):
     '''Return ``self+other``.'''
 
@@ -860,6 +881,9 @@ class ChainedTransforms(Transforms):
 
   def refined(self, references):
     return chain((item.refined(references[start:stop]) for item, start, stop in zip(self._items, self._offsets[:-1], self._offsets[1:])), self.fromdims)
+
+  def edges(self, references):
+    return chain((item.edges(references[start:stop]) for item, start, stop in zip(self._items, self._offsets[:-1], self._offsets[1:])), self.fromdims-1)
 
   def unchain(self):
     yield from self._items

--- a/tests/test_elementseq.py
+++ b/tests/test_elementseq.py
@@ -121,8 +121,8 @@ common(
   check=[square*line]*2+[triangle*line]*2,
   checkndims=3)
 common(
-  'ChildReferences',
-  seq=nutils.elementseq.ChildReferences(nutils.elementseq.PlainReferences([square, triangle], 2)),
+  'DerivedReferences',
+  seq=nutils.elementseq.DerivedReferences(nutils.elementseq.PlainReferences([square, triangle], 2), 'child_refs', 2),
   check=[square]*4+[triangle]*4,
   checkndims=2)
 

--- a/tests/test_elementseq.py
+++ b/tests/test_elementseq.py
@@ -6,8 +6,7 @@ line = nutils.element.LineReference()
 square = line*line
 triangle = nutils.element.TriangleReference()
 
-@parametrize
-class common(TestCase):
+class Common:
 
   def test_fromdims(self):
     self.assertEqual(self.seq.ndims, self.checkndims)
@@ -88,46 +87,54 @@ class common(TestCase):
   def test_getpoints(self):
     self.assertEqual(self.seq.getpoints('bezier', 2), tuple(ref.getpoints('bezier', 2) for ref in self.check))
 
-common(
-  'EmptyReferences',
-  seq=nutils.elementseq.EmptyReferences(2),
-  check=[],
-  checkndims=2)
-common(
-  'PlainReferences',
-  seq=nutils.elementseq.PlainReferences([square, triangle], 2),
-  check=[square, triangle],
-  checkndims=2)
-common(
-  'UniformReferences',
-  seq=nutils.elementseq.UniformReferences(square, 3),
-  check=[square]*3,
-  checkndims=2)
-common(
-  'SelectedReferences',
-  seq=nutils.elementseq.SelectedReferences(nutils.elementseq.PlainReferences([square, triangle, square], 2), [1, 2]),
-  check=[triangle, square],
-  checkndims=2)
-common(
-  'ChainedReferences',
-  seq=nutils.elementseq.ChainedReferences([nutils.elementseq.PlainReferences([square, triangle], 2)]*2),
-  check=[square, triangle]*2,
-  checkndims=2)
-common(
-  'RepeatedReferences',
-  seq=nutils.elementseq.RepeatedReferences(nutils.elementseq.PlainReferences([square, triangle, square], 2), 2),
-  check=[square, triangle, square]*2,
-  checkndims=2)
-common(
-  'ProductReferences',
-  seq=nutils.elementseq.ProductReferences(nutils.elementseq.PlainReferences([square, triangle], 2), nutils.elementseq.PlainReferences([line, line], 1)),
-  check=[square*line]*2+[triangle*line]*2,
-  checkndims=3)
-common(
-  'DerivedReferences',
-  seq=nutils.elementseq.DerivedReferences(nutils.elementseq.PlainReferences([square, triangle], 2), 'child_refs', 2),
-  check=[square]*4+[triangle]*4,
-  checkndims=2)
+class EmptyReferences(TestCase, Common):
+  def setUp(self):
+    self.seq = nutils.elementseq.EmptyReferences(2)
+    self.check = []
+    self.checkndims = 2
+
+class PlainReferences(TestCase, Common):
+  def setUp(self):
+    self.seq = nutils.elementseq.PlainReferences([square, triangle], 2)
+    self.check = [square, triangle]
+    self.checkndims = 2
+
+class UniformReferences(TestCase, Common):
+  def setUp(self):
+    self.seq = nutils.elementseq.UniformReferences(square, 3)
+    self.check = [square]*3
+    self.checkndims = 2
+
+class SelectedReferences(TestCase, Common):
+  def setUp(self):
+    self.seq = nutils.elementseq.SelectedReferences(nutils.elementseq.PlainReferences([square, triangle, square], 2), [1, 2])
+    self.check = [triangle, square]
+    self.checkndims = 2
+
+class ChainedReferences(TestCase, Common):
+  def setUp(self):
+    self.seq = nutils.elementseq.ChainedReferences([nutils.elementseq.PlainReferences([square, triangle], 2)]*2)
+    self.check = [square, triangle]*2
+    self.checkndims = 2
+
+class RepeatedReferences(TestCase, Common):
+  def setUp(self):
+    self.seq = nutils.elementseq.RepeatedReferences(nutils.elementseq.PlainReferences([square, triangle, square], 2), 2)
+    self.check = [square, triangle, square]*2
+    self.checkndims = 2
+
+class ProductReferences(TestCase, Common):
+  def setUp(self):
+    self.seq = nutils.elementseq.ProductReferences(nutils.elementseq.PlainReferences([square, triangle], 2), nutils.elementseq.PlainReferences([line, line], 1))
+    self.check = [square*line]*2+[triangle*line]*2
+    self.checkndims = 3
+
+class DerivedReferences(TestCase, Common):
+  def setUp(self):
+    self.seq = nutils.elementseq.DerivedReferences(nutils.elementseq.PlainReferences([square, triangle], 2), 'child_refs', 2)
+    self.check = [square]*4+[triangle]*4
+    self.checkndims = 2
+
 
 class exceptions(TestCase):
 

--- a/tests/test_elementseq.py
+++ b/tests/test_elementseq.py
@@ -82,6 +82,9 @@ class common(TestCase):
   def test_children(self):
     self.assertEqual(tuple(self.seq.children), tuple(itertools.chain.from_iterable(ref.child_refs for ref in self.check)))
 
+  def test_edges(self):
+    self.assertEqual(tuple(self.seq.edges), tuple(itertools.chain.from_iterable(ref.edge_refs for ref in self.check)))
+
   def test_getpoints(self):
     self.assertEqual(self.seq.getpoints('bezier', 2), tuple(ref.getpoints('bezier', 2) for ref in self.check))
 

--- a/tests/test_elementseq.py
+++ b/tests/test_elementseq.py
@@ -67,7 +67,7 @@ class common(TestCase):
     self.assertEqual(tuple(self.seq), tuple(self.check))
 
   def test_add(self):
-    self.assertEqual(tuple(self.seq+nutils.elementseq.PlainReferences((), self.checkndims)), tuple(self.check))
+    self.assertEqual(tuple(self.seq+nutils.elementseq.EmptyReferences(self.checkndims)), tuple(self.check))
     self.assertEqual(tuple(self.seq+self.seq), tuple(self.check)+tuple(self.check))
 
   def test_mul_int(self):
@@ -85,6 +85,11 @@ class common(TestCase):
   def test_getpoints(self):
     self.assertEqual(self.seq.getpoints('bezier', 2), tuple(ref.getpoints('bezier', 2) for ref in self.check))
 
+common(
+  'EmptyReferences',
+  seq=nutils.elementseq.EmptyReferences(2),
+  check=[],
+  checkndims=2)
 common(
   'PlainReferences',
   seq=nutils.elementseq.PlainReferences([square, triangle], 2),
@@ -169,7 +174,7 @@ class asreferences(TestCase):
       nutils.elementseq.asreferences(value, 2)
 
   def test_References_list_empty(self):
-    self.assertEqual(nutils.elementseq.asreferences([], 2), nutils.elementseq.PlainReferences([], 2))
+    self.assertEqual(nutils.elementseq.asreferences([], 2), nutils.elementseq.EmptyReferences(2))
 
   def test_References_list_pluriform(self):
     self.assertEqual(nutils.elementseq.asreferences([square, triangle], 2), nutils.elementseq.PlainReferences([square, triangle], 2))

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -81,7 +81,7 @@ class gmsh(TestCase):
     boundary1 = self.domain.refined.boundary
     boundary2 = self.domain.boundary.refined
     assert len(boundary1) == len(boundary2) == len(self.domain.boundary) * element.getsimplex(self.domain.ndims-1).nchildren
-    assert set(boundary1.transforms) == set(boundary2.transforms)
+    assert set(map(transform.canonical, boundary1.transforms)) == set(map(transform.canonical, boundary2.transforms))
     assert all(boundary2.references[boundary2.transforms.index(trans)] == ref for ref, trans in zip(boundary1.references, boundary1.transforms))
 
   def test_refinesubset(self):
@@ -89,7 +89,7 @@ class gmsh(TestCase):
     boundary1 = domain.refined.boundary
     boundary2 = domain.boundary.refined
     assert len(boundary1) == len(boundary2) == len(domain.boundary) * element.getsimplex(domain.ndims-1).nchildren
-    assert set(boundary1.transforms) == set(boundary2.transforms)
+    assert set(map(transform.canonical, boundary1.transforms)) == set(map(transform.canonical, boundary2.transforms))
     assert all(boundary2.references[boundary2.transforms.index(trans)] == ref for ref, trans in zip(boundary1.references, boundary1.transforms))
 
 for ndims in 2, 3:

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -617,8 +617,8 @@ class common(TestCase):
       check = check.refined
 
 common(
-  'UnstructuredTopology',
-  topo=topology.UnstructuredTopology(elementseq.asreferences([element.PointReference()], 0), transformseq.PlainTransforms([(transform.Identifier(0, 'test'),)], 0)),
+  'Topology',
+  topo=topology.Topology(elementseq.asreferences([element.PointReference()], 0), transformseq.PlainTransforms([(transform.Identifier(0, 'test'),)], 0), transformseq.PlainTransforms([(transform.Identifier(0, 'test'),)], 0)),
   hasboundary=False)
 common(
   'StructuredTopology:2D',

--- a/tests/test_transformseq.py
+++ b/tests/test_transformseq.py
@@ -125,6 +125,13 @@ class common(TestCase):
     for i, trans in enumerate(ctransforms):
       self.assertEqual(refined.index(trans), i)
 
+  @parametrize.enable_if(lambda checkfromdims, **kwargs: checkfromdims > 0)
+  def test_edges(self):
+    edges = self.seq.edges(self.checkrefs)
+    etransforms = (trans+(etrans,) for trans, ref in zip(self.check, self.checkrefs) for etrans in ref.edge_transforms)
+    for i, trans in enumerate(etransforms):
+      self.assertEqual(edges.index(trans), i)
+
 point = nutils.element.PointReference()
 line = nutils.element.LineReference()
 square = line*line

--- a/tests/test_transformseq.py
+++ b/tests/test_transformseq.py
@@ -1,9 +1,8 @@
 from nutils.testing import TestCase, parametrize
 import nutils.transformseq, nutils.elementseq, nutils.element
-import unittest, numpy, itertools
+import unittest, numpy, itertools, functools, types
 
-@parametrize
-class common(TestCase):
+class Common:
 
   def test_fromdims(self):
     self.assertEqual(self.seq.fromdims, self.checkfromdims)
@@ -125,7 +124,8 @@ class common(TestCase):
     for i, trans in enumerate(ctransforms):
       self.assertEqual(refined.index(trans), i)
 
-  @parametrize.enable_if(lambda checkfromdims, **kwargs: checkfromdims > 0)
+class Edges:
+
   def test_edges(self):
     edges = self.seq.edges(self.checkrefs)
     etransforms = (trans+(etrans,) for trans, ref in zip(self.check, self.checkrefs) for etrans in ref.edge_transforms)
@@ -160,129 +160,149 @@ s13 = nutils.transform.Shift([1.,3.])
 
 c00,c01,c10,c11 = square.child_transforms
 
-common(
-  'EmptyTransforms:1D',
-  seq=nutils.transformseq.EmptyTransforms(fromdims=1),
-  check=[],
-  checkmissing=[(l1,s0),(x1,s4),(r1,s0)],
-  checkrefs=nutils.elementseq.EmptyReferences(1),
-  checkfromdims=1)
-common(
-  'PlainTransforms:1D',
-  seq=nutils.transformseq.PlainTransforms([(x1,s0),(x1,s1),(x1,s2),(x1,s3)], fromdims=1),
-  check=[(x1,s0),(x1,s1),(x1,s2),(x1,s3)],
-  checkmissing=[(l1,s0),(x1,s4),(r1,s0)],
-  checkrefs=nutils.elementseq.asreferences([line]*4, 1),
-  checkfromdims=1)
-common(
-  'PlainTransforms:2D',
-  seq=nutils.transformseq.PlainTransforms([(x2,s00),(x2,s01),(x2,s10),(x2,s11)], fromdims=2),
-  check=[(x2,s00),(x2,s01),(x2,s10),(x2,s11)],
-  checkmissing=[(l2,s00),(x2,s02),(x2,s12),(r2,s00)],
-  checkrefs=nutils.elementseq.asreferences([square,square,triangle,triangle], 2),
-  checkfromdims=2)
-common(
-  'MaskedTransforms',
-  seq=nutils.transformseq.MaskedTransforms(nutils.transformseq.PlainTransforms([(x2,s00),(x2,s01),(x2,s10),(x2,s11)], fromdims=2), [0,2]),
-  check=[(x2,s00),(x2,s10)],
-  checkmissing=[(l2,s00),(x2,s01),(x2,s11),(x2,s02),(x2,s12),(r2,s00)],
-  checkrefs=nutils.elementseq.asreferences([square,triangle], 2),
-  checkfromdims=2)
-common(
-  'ReorderedTransforms',
-  seq=nutils.transformseq.ReorderedTransforms(nutils.transformseq.PlainTransforms([(x2,s00),(x2,s01),(x2,s10),(x2,s11)], fromdims=2), [0,2,3,1]),
-  check=[(x2,s00),(x2,s10),(x2,s11),(x2,s01)],
-  checkmissing=[(l2,s00),(x2,s02),(x2,s12),(r2,s00)],
-  checkrefs=nutils.elementseq.asreferences([square]*4, 2),
-  checkfromdims=2)
-common(
-  'DerivedTransforms',
-  seq=nutils.transformseq.DerivedTransforms(nutils.transformseq.PlainTransforms([(x1,s0),(x1,s1)], fromdims=1), nutils.elementseq.asreferences([line,line], 1), 'child_transforms', 1),
-  check=[(x1,s0,c0),(x1,s0,c1),(x1,s1,c0),(x1,s1,c1)],
-  checkmissing=[(l1,s0),(x1,s0),(x1,s1),(r1,s0)],
-  checkrefs=nutils.elementseq.asreferences([line]*4, 1),
-  checkfromdims=1)
-common(
-  'UniformDerivedTransforms',
-  seq=nutils.transformseq.UniformDerivedTransforms(nutils.transformseq.PlainTransforms([(x1,s0),(x1,s1)], fromdims=1), line, 'child_transforms', 1),
-  check=[(x1,s0,c0),(x1,s0,c1),(x1,s1,c0),(x1,s1,c1)],
-  checkmissing=[(l1,s0),(x1,s0),(x1,s1),(r1,s0)],
-  checkrefs=nutils.elementseq.asreferences([line]*4, 1),
-  checkfromdims=1)
-common(
-  'ChainedTransforms',
-  seq=nutils.transformseq.ChainedTransforms([nutils.transformseq.PlainTransforms([(x1,s0),(x1,s1)], fromdims=1), nutils.transformseq.PlainTransforms([(x1,s2),(x1,s3)], fromdims=1)]),
-  check=[(x1,s0),(x1,s1),(x1,s2),(x1,s3)],
-  checkmissing=[(l1,s0),(x1,s4),(r1,s0)],
-  checkrefs=nutils.elementseq.asreferences([line]*4, 1),
-  checkfromdims=1)
+class EmptyTransforms(TestCase, Common, Edges):
+  def setUp(self):
+    self.seq = nutils.transformseq.EmptyTransforms(fromdims=1)
+    self.check = ()
+    self.checkmissing = (l1,s0),(x1,s4),(r1,s0)
+    self.checkrefs = nutils.elementseq.EmptyReferences(1)
+    self.checkfromdims = 1
 
-common(
-  'StructuredTransforms:1D',
-  seq=nutils.transformseq.StructuredTransforms(x1, [nutils.transformseq.DimAxis(0,4,False)], 0),
-  check=[(x1,s0),(x1,s1),(x1,s2),(x1,s3)],
-  checkmissing=[(l1,s0),(x1,s4),(r1,s0),(x1,c1)],
-  checkrefs=nutils.elementseq.asreferences([line]*4, 1),
-  checkfromdims=1)
-common(
-  'StructuredTransforms:1D,refined',
-  seq=nutils.transformseq.StructuredTransforms(x1, [nutils.transformseq.DimAxis(0,4,False)], 1),
-  check=[(x1,s0,c0),(x1,s0,c1),(x1,s1,c0),(x1,s1,c1)],
-  checkmissing=[(l1,s0),(x1,s0),(x1,s1),(x1,s0,s1),(r1,s0)],
-  checkrefs=nutils.elementseq.asreferences([line]*4, 1),
-  checkfromdims=1)
-for i, side, s, e in (3,False,s3,e1), (3,True,s2,e0):
-  trans = (x1,s,e)
-  common(
-    'StructuredTransforms:1D,boundary,side={}'.format(side),
-    seq=nutils.transformseq.StructuredTransforms(x1, [nutils.transformseq.BndAxis(i,i,0,side)], 0),
-    check=[trans],
-    checkmissing=[t for t in [(x1,s0,e0),(x1,s3,e1),(x1,s4,e0)] if t != trans],
-    checkrefs=nutils.elementseq.asreferences([point], 0),
-    checkfromdims=0)
-common(
-  'StructuredTransforms:1D,interfaces,side=False',
-  seq=nutils.transformseq.StructuredTransforms(x1, [nutils.transformseq.IntAxis(0,4,0,False)], 0),
-  check=[(x1,s1,e1),(x1,s2,e1),(x1,s3,e1)],
-  checkmissing=[(x1,s0,e1),(x1,s0,e0),(x1,s1,e0),(x1,s2,e0),(x1,s3,e0)],
-  checkrefs=nutils.elementseq.asreferences([point]*3, 0),
-  checkfromdims=0)
-common(
-  'StructuredTransforms:1D,interfaces,side=True',
-  seq=nutils.transformseq.StructuredTransforms(x1, [nutils.transformseq.IntAxis(0,4,0,True)], 0),
-  check=[(x1,s0,e0),(x1,s1,e0),(x1,s2,e0)],
-  checkmissing=[(x1,s3,e0),(x1,s0,e1),(x1,s1,e1),(x1,s2,e1),(x1,s3,e1)],
-  checkrefs=nutils.elementseq.asreferences([point]*3, 0),
-  checkfromdims=0)
-common(
-  'StructuredTransforms:1D,periodic,interfaces,side=False',
-  seq=nutils.transformseq.StructuredTransforms(x1, [nutils.transformseq.PIntAxis(0,4,0,False)], 0),
-  check=[(x1,s1,e1),(x1,s2,e1),(x1,s3,e1),(x1,s0,e1)],
-  checkmissing=[(x1,s0,e0),(x1,s1,e0),(x1,s2,e0),(x1,s3,e0),(x1,s4,e0)],
-  checkrefs=nutils.elementseq.asreferences([point]*3, 0),
-  checkfromdims=0)
-common(
-  'StructuredTransforms:1D,periodic,interfaces,side=True',
-  seq=nutils.transformseq.StructuredTransforms(x1, [nutils.transformseq.PIntAxis(0,4,0,True)], 0),
-  check=[(x1,s0,e0),(x1,s1,e0),(x1,s2,e0),(x1,s3,e0)],
-  checkmissing=[(x1,s0,e1),(x1,s1,e1),(x1,s2,e1),(x1,s3,e1),(x1,s4,e1)],
-  checkrefs=nutils.elementseq.asreferences([point]*3, 0),
-  checkfromdims=0)
+class PlainTransforms1D(TestCase, Common, Edges):
+  def setUp(self):
+    self.seq = nutils.transformseq.PlainTransforms([(x1,s0),(x1,s1),(x1,s2),(x1,s3)], fromdims=1)
+    self.check = (x1,s0),(x1,s1),(x1,s2),(x1,s3)
+    self.checkmissing = (l1,s0),(x1,s4),(r1,s0)
+    self.checkrefs = nutils.elementseq.asreferences([line]*4, 1)
+    self.checkfromdims = 1
 
-common(
-  'StructuredTransforms:2D',
-  seq=nutils.transformseq.StructuredTransforms(x2, [nutils.transformseq.DimAxis(0,2,False),nutils.transformseq.DimAxis(2,4,False)], 0),
-  check=[(x2,s02),(x2,s03),(x2,s12),(x2,s13)],
-  checkmissing=[(x2,s00),(x2,s01),(x2,s10),(x2,s11)],
-  checkrefs=nutils.elementseq.asreferences([square]*4, 2),
-  checkfromdims=2)
-common(
-  'StructuredTransforms:2D,refined',
-  seq=nutils.transformseq.StructuredTransforms(x2, [nutils.transformseq.DimAxis(0,2,False),nutils.transformseq.DimAxis(2,4,False)], 1),
-  check=[(x2,s01,c00),(x2,s01,c01),(x2,s01,c10),(x2,s01,c11)],
-  checkmissing=[(x2,s00,c00)],
-  checkrefs=nutils.elementseq.asreferences([square]*4, 2),
-  checkfromdims=2)
+class PlainTransforms2D(TestCase, Common, Edges):
+  def setUp(self):
+    self.seq = nutils.transformseq.PlainTransforms([(x2,s00),(x2,s01),(x2,s10),(x2,s11)], fromdims=2)
+    self.check = (x2,s00),(x2,s01),(x2,s10),(x2,s11)
+    self.checkmissing = (l2,s00),(x2,s02),(x2,s12),(r2,s00)
+    self.checkrefs = nutils.elementseq.asreferences([square,square,triangle,triangle], 2)
+    self.checkfromdims = 2
+
+class MaskedTransforms(TestCase, Common, Edges):
+  def setUp(self):
+    self.seq = nutils.transformseq.MaskedTransforms(nutils.transformseq.PlainTransforms([(x2,s00),(x2,s01),(x2,s10),(x2,s11)], fromdims=2), [0,2])
+    self.check = (x2,s00),(x2,s10)
+    self.checkmissing = (l2,s00),(x2,s01),(x2,s11),(x2,s02),(x2,s12),(r2,s00)
+    self.checkrefs = nutils.elementseq.asreferences([square,triangle], 2)
+    self.checkfromdims = 2
+
+class ReorderedTransforms(TestCase, Common, Edges):
+  def setUp(self):
+    self.seq = nutils.transformseq.ReorderedTransforms(nutils.transformseq.PlainTransforms([(x2,s00),(x2,s01),(x2,s10),(x2,s11)], fromdims=2), [0,2,3,1])
+    self.check = (x2,s00),(x2,s10),(x2,s11),(x2,s01)
+    self.checkmissing = (l2,s00),(x2,s02),(x2,s12),(r2,s00)
+    self.checkrefs = nutils.elementseq.asreferences([square]*4, 2)
+    self.checkfromdims = 2
+
+class DerivedTransforms(TestCase, Common, Edges):
+  def setUp(self):
+    self.seq = nutils.transformseq.DerivedTransforms(nutils.transformseq.PlainTransforms([(x1,s0),(x1,s1)], fromdims=1), nutils.elementseq.asreferences([line,line], 1), 'child_transforms', 1)
+    self.check = (x1,s0,c0),(x1,s0,c1),(x1,s1,c0),(x1,s1,c1)
+    self.checkmissing = (l1,s0),(x1,s0),(x1,s1),(r1,s0)
+    self.checkrefs = nutils.elementseq.asreferences([line]*4, 1)
+    self.checkfromdims = 1
+
+class UniformDerivedTransforms(TestCase, Common, Edges):
+  def setUp(self):
+    self.seq = nutils.transformseq.UniformDerivedTransforms(nutils.transformseq.PlainTransforms([(x1,s0),(x1,s1)], fromdims=1), line, 'child_transforms', 1)
+    self.check = (x1,s0,c0),(x1,s0,c1),(x1,s1,c0),(x1,s1,c1)
+    self.checkmissing = (l1,s0),(x1,s0),(x1,s1),(r1,s0)
+    self.checkrefs = nutils.elementseq.asreferences([line]*4, 1)
+    self.checkfromdims = 1
+
+class ChainedTransforms(TestCase, Common, Edges):
+  def setUp(self):
+    self.seq = nutils.transformseq.ChainedTransforms([nutils.transformseq.PlainTransforms([(x1,s0),(x1,s1)], fromdims=1), nutils.transformseq.PlainTransforms([(x1,s2),(x1,s3)], fromdims=1)])
+    self.check = (x1,s0),(x1,s1),(x1,s2),(x1,s3)
+    self.checkmissing = (l1,s0),(x1,s4),(r1,s0)
+    self.checkrefs = nutils.elementseq.asreferences([line]*4, 1)
+    self.checkfromdims = 1
+
+class StructuredTransforms1D(TestCase, Common, Edges):
+  def setUp(self):
+    self.seq = nutils.transformseq.StructuredTransforms(x1, [nutils.transformseq.DimAxis(0,4,False)], 0)
+    self.check = (x1,s0),(x1,s1),(x1,s2),(x1,s3)
+    self.checkmissing = (l1,s0),(x1,s4),(r1,s0),(x1,c1)
+    self.checkrefs = nutils.elementseq.asreferences([line]*4, 1)
+    self.checkfromdims = 1
+
+class StructuredTransforms1DRefined(TestCase, Common, Edges):
+  def setUp(self):
+    self.seq = nutils.transformseq.StructuredTransforms(x1, [nutils.transformseq.DimAxis(0,4,False)], 1)
+    self.check = (x1,s0,c0),(x1,s0,c1),(x1,s1,c0),(x1,s1,c1)
+    self.checkmissing = (l1,s0),(x1,s0),(x1,s1),(x1,s0,s1),(r1,s0)
+    self.checkrefs = nutils.elementseq.asreferences([line]*4, 1)
+    self.checkfromdims = 1
+
+class StructuredTransforms1DLeft(TestCase, Common):
+  def setUp(self):
+    self.seq = nutils.transformseq.StructuredTransforms(x1, [nutils.transformseq.BndAxis(3,3,0,False)], 0)
+    self.check = (x1,s3,e1),
+    self.checkmissing = (x1,s0,e0),(x1,s2,e0),(x1,s4,e0)
+    self.checkrefs = nutils.elementseq.asreferences([point], 0)
+    self.checkfromdims = 0
+
+class StructuredTransforms1DRight(TestCase, Common):
+  def setUp(self):
+    self.seq = nutils.transformseq.StructuredTransforms(x1, [nutils.transformseq.BndAxis(3,3,0,True)], 0)
+    self.check = (x1,s2,e0),
+    self.checkmissing = (x1,s0,e0),(x1,s3,e1),(x1,s4,e0)
+    self.checkrefs = nutils.elementseq.asreferences([point], 0)
+    self.checkfromdims = 0
+
+class StructuredTransforms1DInterfacesLeft(TestCase, Common):
+  def setUp(self):
+    self.seq = nutils.transformseq.StructuredTransforms(x1, [nutils.transformseq.IntAxis(0,4,0,False)], 0)
+    self.check = (x1,s1,e1),(x1,s2,e1),(x1,s3,e1)
+    self.checkmissing = (x1,s0,e1),(x1,s0,e0),(x1,s1,e0),(x1,s2,e0),(x1,s3,e0)
+    self.checkrefs = nutils.elementseq.asreferences([point]*3, 0)
+    self.checkfromdims = 0
+
+class StructuredTransforms1DInterfacesRight(TestCase, Common):
+  def setUp(self):
+    self.seq = nutils.transformseq.StructuredTransforms(x1, [nutils.transformseq.IntAxis(0,4,0,True)], 0)
+    self.check = (x1,s0,e0),(x1,s1,e0),(x1,s2,e0)
+    self.checkmissing = (x1,s3,e0),(x1,s0,e1),(x1,s1,e1),(x1,s2,e1),(x1,s3,e1)
+    self.checkrefs = nutils.elementseq.asreferences([point]*3, 0)
+    self.checkfromdims = 0
+
+class StructuredTransforms1DPeriodicInterfacesLeft(TestCase, Common):
+  def setUp(self):
+    self.seq = nutils.transformseq.StructuredTransforms(x1, [nutils.transformseq.PIntAxis(0,4,0,False)], 0)
+    self.check = (x1,s1,e1),(x1,s2,e1),(x1,s3,e1),(x1,s0,e1)
+    self.checkmissing = (x1,s0,e0),(x1,s1,e0),(x1,s2,e0),(x1,s3,e0),(x1,s4,e0)
+    self.checkrefs = nutils.elementseq.asreferences([point]*3, 0)
+    self.checkfromdims = 0
+
+class StructuredTransforms1DPeriodicInterfacesRight(TestCase, Common):
+  def setUp(self):
+    self.seq = nutils.transformseq.StructuredTransforms(x1, [nutils.transformseq.PIntAxis(0,4,0,True)], 0)
+    self.check = (x1,s0,e0),(x1,s1,e0),(x1,s2,e0),(x1,s3,e0)
+    self.checkmissing = (x1,s0,e1),(x1,s1,e1),(x1,s2,e1),(x1,s3,e1),(x1,s4,e1)
+    self.checkrefs = nutils.elementseq.asreferences([point]*3, 0)
+    self.checkfromdims = 0
+
+class StructuredTransforms2D(TestCase, Common, Edges):
+  def setUp(self):
+    self.seq = nutils.transformseq.StructuredTransforms(x2, [nutils.transformseq.DimAxis(0,2,False),nutils.transformseq.DimAxis(2,4,False)], 0)
+    self.check = (x2,s02),(x2,s03),(x2,s12),(x2,s13)
+    self.checkmissing = (x2,s00),(x2,s01),(x2,s10),(x2,s11)
+    self.checkrefs = nutils.elementseq.asreferences([square]*4, 2)
+    self.checkfromdims = 2
+
+class StructuredTransforms2DRefined(TestCase, Common, Edges):
+  def setUp(self):
+    self.seq = nutils.transformseq.StructuredTransforms(x2, [nutils.transformseq.DimAxis(0,2,False),nutils.transformseq.DimAxis(2,4,False)], 1)
+    self.check = (x2,s01,c00),(x2,s01,c01),(x2,s01,c10),(x2,s01,c11)
+    self.checkmissing = (x2,s00,c00),
+    self.checkrefs = nutils.elementseq.asreferences([square]*4, 2)
+    self.checkfromdims = 2
 
 class exceptions(TestCase):
 

--- a/tests/test_transformseq.py
+++ b/tests/test_transformseq.py
@@ -63,7 +63,7 @@ class common(TestCase):
     self.assertEqual(tuple(self.seq), tuple(self.check))
 
   def test_add(self):
-    self.assertEqual(tuple(self.seq+nutils.transformseq.PlainTransforms((), self.checkfromdims)), tuple(self.check))
+    self.assertEqual(tuple(self.seq+nutils.transformseq.EmptyTransforms(self.checkfromdims)), tuple(self.check))
     self.assertEqual(tuple(self.seq+self.seq), tuple(self.check)+tuple(self.check))
 
   def test_index_with_tail(self):
@@ -153,6 +153,13 @@ s13 = nutils.transform.Shift([1.,3.])
 
 c00,c01,c10,c11 = square.child_transforms
 
+common(
+  'EmptyTransforms:1D',
+  seq=nutils.transformseq.EmptyTransforms(fromdims=1),
+  check=[],
+  checkmissing=[(l1,s0),(x1,s4),(r1,s0)],
+  checkrefs=nutils.elementseq.EmptyReferences(1),
+  checkfromdims=1)
 common(
   'PlainTransforms:1D',
   seq=nutils.transformseq.PlainTransforms([(x1,s0),(x1,s1),(x1,s2),(x1,s3)], fromdims=1),

--- a/tests/test_transformseq.py
+++ b/tests/test_transformseq.py
@@ -189,15 +189,15 @@ common(
   checkrefs=nutils.elementseq.asreferences([square]*4, 2),
   checkfromdims=2)
 common(
-  'RefinedTransforms',
-  seq=nutils.transformseq.RefinedTransforms(nutils.transformseq.PlainTransforms([(x1,s0),(x1,s1)], fromdims=1), nutils.elementseq.asreferences([line,line], 1)),
+  'DerivedTransforms',
+  seq=nutils.transformseq.DerivedTransforms(nutils.transformseq.PlainTransforms([(x1,s0),(x1,s1)], fromdims=1), nutils.elementseq.asreferences([line,line], 1), 'child_transforms', 1),
   check=[(x1,s0,c0),(x1,s0,c1),(x1,s1,c0),(x1,s1,c1)],
   checkmissing=[(l1,s0),(x1,s0),(x1,s1),(r1,s0)],
   checkrefs=nutils.elementseq.asreferences([line]*4, 1),
   checkfromdims=1)
 common(
-  'UniformRefinedTransforms',
-  seq=nutils.transformseq.UniformRefinedTransforms(nutils.transformseq.PlainTransforms([(x1,s0),(x1,s1)], fromdims=1), line),
+  'UniformDerivedTransforms',
+  seq=nutils.transformseq.UniformDerivedTransforms(nutils.transformseq.PlainTransforms([(x1,s0),(x1,s1)], fromdims=1), line, 'child_transforms', 1),
   check=[(x1,s0,c0),(x1,s0,c1),(x1,s1,c0),(x1,s1,c1)],
   checkmissing=[(l1,s0),(x1,s0),(x1,s1),(r1,s0)],
   checkrefs=nutils.elementseq.asreferences([line]*4, 1),
@@ -287,22 +287,22 @@ class exceptions(TestCase):
     with self.assertRaisesRegex(ValueError, 'expected transforms with fromdims=2, but got .*'):
       nutils.transformseq.PlainTransforms([(x1,s0),(x2,s00)], 2)
 
-  def test_RefinedTransforms_length_mismatch(self):
+  def test_DerivedTransforms_length_mismatch(self):
     transforms = nutils.transformseq.PlainTransforms([(x1,s0),(x1,s1)], 1)
     references = nutils.elementseq.PlainReferences([line]*3, 1)
     with self.assertRaisesRegex(ValueError, '`parent` and `parent_references` should have the same length'):
-      nutils.transformseq.RefinedTransforms(transforms, references)
+      nutils.transformseq.DerivedTransforms(transforms, references, 'child_transforms', 1)
 
-  def test_RefinedTransforms_ndims_mismatch(self):
+  def test_DerivedTransforms_ndims_mismatch(self):
     transforms = nutils.transformseq.PlainTransforms([(x1,s0),(x1,s1)], 1)
     references = nutils.elementseq.PlainReferences([square]*2, 2)
     with self.assertRaisesRegex(ValueError, '`parent` and `parent_references` have different dimensions'):
-      nutils.transformseq.RefinedTransforms(transforms, references)
+      nutils.transformseq.DerivedTransforms(transforms, references, 'child_transforms', 1)
 
-  def test_UniformRefinedTransforms_ndims_mismatch(self):
+  def test_UniformDerivedTransforms_ndims_mismatch(self):
     transforms = nutils.transformseq.PlainTransforms([(x1,s0),(x1,s1)], 1)
     with self.assertRaisesRegex(ValueError, '`parent` and `parent_reference` have different dimensions'):
-      nutils.transformseq.UniformRefinedTransforms(transforms, square)
+      nutils.transformseq.UniformDerivedTransforms(transforms, square, 'child_transforms', 1)
 
   def test_ChainedTransforms_no_items(self):
     with self.assertRaisesRegex(ValueError, 'Empty chain.'):

--- a/tests/test_transformseq.py
+++ b/tests/test_transformseq.py
@@ -182,6 +182,13 @@ common(
   checkrefs=nutils.elementseq.asreferences([square,triangle], 2),
   checkfromdims=2)
 common(
+  'ReorderedTransforms',
+  seq=nutils.transformseq.ReorderedTransforms(nutils.transformseq.PlainTransforms([(x2,s00),(x2,s01),(x2,s10),(x2,s11)], fromdims=2), [0,2,3,1]),
+  check=[(x2,s00),(x2,s10),(x2,s11),(x2,s01)],
+  checkmissing=[(l2,s00),(x2,s02),(x2,s12),(r2,s00)],
+  checkrefs=nutils.elementseq.asreferences([square]*4, 2),
+  checkfromdims=2)
+common(
   'RefinedTransforms',
   seq=nutils.transformseq.RefinedTransforms(nutils.transformseq.PlainTransforms([(x1,s0),(x1,s1)], fromdims=1), nutils.elementseq.asreferences([line,line], 1)),
   check=[(x1,s0,c0),(x1,s0,c1),(x1,s1,c0),(x1,s1,c1)],


### PR DESCRIPTION
The goal of this PR is to eliminate `PlainTransforms` in the `UnionTopology` and in the `boundary` and `interfaces` attributes of the `Topology` base class.