### PR TITLE
Types

### DIFF
--- a/nutils/transformseq.py
+++ b/nutils/transformseq.py
@@ -417,6 +417,7 @@ class IdentifierTransforms(Transforms):
   def __getitem__(self, index):
     if not numeric.isint(index):
       return super().__getitem__(index)
+    index = int(index) # make sure that index is a Python integer rather than numpy.intxx
     return transform.Identifier(self.fromdims, self._name, numeric.normdim(self._length, index)),
 
   def __len__(self):

--- a/nutils/types.py
+++ b/nutils/types.py
@@ -297,7 +297,7 @@ def nutils_hash(data):
   elif t is frozenset:
     hargs = sorted(map(nutils_hash, data))
   else:
-    raise TypeError('unhashable type: {!r}'.format(data))
+    raise TypeError('unhashable type: {!r} {!r}'.format(data, t))
 
   h = hashlib.sha1(t.__name__.encode()+b'\0')
   for harg in hargs:


### PR DESCRIPTION
Fixes hashing of Identifier instances resulting from IdentifierTransforms(..)[numpy.in64(i)]. Since all integer types test true for equality, including in types.Singleton, we should probably consider adding support for it in nutils_hash.