### PR TITLE
add webhook repo_token

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
     - PYTHON=python3
     - COVERALLS_PARALLEL=true
 notifications:
-  webhooks: https://coveralls.io/webhook
+  webhooks: https://coveralls.io/webhook?repo_token=oymJVraNAf4i2QtRr7QO0aoag5Mhe9END
 cache: pip
 matrix:
   include:


### PR DESCRIPTION
Experiment to see if this makes coveralls.io happy, even though the [documentation](https://docs.coveralls.io/parallel-build-webhook) states that "with public repos, you can omit the repo token".