### PR TITLE
disable parallel tests on macOS

### DIFF
--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -1,8 +1,9 @@
-import unittest, os, multiprocessing, time
+import unittest, os, multiprocessing, time, sys
 from nutils import parallel
 
 canfork = hasattr(os, 'fork')
 
+@unittest.skipIf(sys.platform == 'darwin', 'fork is unreliable (in combination with matplotlib)')
 class Test(unittest.TestCase):
 
   def setUp(self):


### PR DESCRIPTION
When running all unittests on macOS with matplotlib installed, sometimes a
forked child segfaults with the message

    libc++abi.dylib: terminating with uncaught exception of type std::runtime_error: Couldn't close file

This patch sweeps the problem under the carpet by disabling unittests with fork
on macOS.