### PR TITLE
improve implementation of Kronecker._get

### DIFF
--- a/nutils/function.py
+++ b/nutils/function.py
@@ -3207,10 +3207,12 @@ class Kronecker(Array):
   def _get(self, axis, item):
     if axis != self.axis:
       return Kronecker(get(self.func, axis-(axis>self.axis), item), self.axis-(axis<=self.axis), self.length, self.pos)
-    if item.simplified == self.pos.simplified or item.isconstant and self.pos.isconstant and item.eval() == self.pos.eval():
+    if item.simplified == self.pos.simplified:
       return self.func
-    if item.isconstant and self.pos.isconstant: # inequality is implied by the previous test
-      return zeros_like(self.func)
+    if item.isconstant and self.pos.isconstant:
+      item, = item.eval()
+      pos, = self.pos.eval()
+      return self.func if item == pos else zeros_like(self.func)
 
   def _add(self, other):
     if isinstance(other, Kronecker) and self.axis == other.axis and self.pos == other.pos:


### PR DESCRIPTION
The current frozenarray implementation tests for equality based on contents and
dtype, meaning that an int32 and int64 array will never test equal. This could
lead to an error in Kronecker._get, which used to test for equality of two
arrays (valid for Numpy arrays of size 1) without realizing that these arrays
were, or could be, frozen. The new implementation unpacks the scalar values
prior to comparison which takes care of this particular bug. A followup commit
will fix frozenarray's overall behaviour.