### PR TITLE
fix: index dtype sparse data structure

### DIFF
--- a/nutils/sparse.py
+++ b/nutils/sparse.py
@@ -346,7 +346,7 @@ def _dtype(itype, vtype):
   return numpy.dtype([('index', itype), ('value', vtype)])
 
 def _uint(n):
-  return numpy.dtype('>u'+str(1 if n <= 256 else 2 if n <= 256**2 else 4 if n <= 256**4 else 8))
+  return numpy.dtype('>u'+str(1 if n < 256 else 2 if n < 256**2 else 4 if n < 256**4 else 8))
 
 def _resize(data, n):
   if data.base is not None:


### PR DESCRIPTION
Playing around with the number of elements in the tutorial and stumbled across a cryptic `Exception: all blocks should be either 1d-sparse or 0` which can be traced back to selecting a wrong data type for indices of sparse data structures, reproduced with the MWE below. PR is a fix, but needs a check from someone who actually knows what is going on.

```
from nutils import mesh, sample, sparse
domain, geom = mesh.line(255)
basis = domain.basis('std', 1)
integral = domain.integral(basis, degree=1)
# stripped down version of solver._integrate_blocks
data = sample.eval_integrals_sparse(integral)
vector = sparse.block(data) # fails due to chosen index dtype
```