### PR TITLE
add SwapInflateTake

### DIFF
--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -1936,7 +1936,7 @@ class TakeDiag(Array):
     if axis < self.ndim - 1:
       return TakeDiag(_take(self.func, index, axis))
     func = _take(Take(self.func, index), index, self.ndim-1)
-    for i in range(self.ndim-1, self.ndim-1+index.ndim):
+    for i in reversed(range(self.ndim-1, self.ndim-1+index.ndim)):
       func = takediag(func, i, i+index.ndim)
     return func
 

--- a/tests/test_evaluable.py
+++ b/tests/test_evaluable.py
@@ -134,6 +134,14 @@ class check(TestCase):
           desired=numpy.take(self.n_op_argsfun, indices, axis=iax),
           actual=evaluable.take(self.op_args, indices, axis=iax))
 
+  def test_take_block(self):
+    for iax, sh in enumerate(self.op_args.shape):
+      if sh >= 2:
+        indices = [[0,sh-1],[sh-1,0]]
+        self.assertFunctionAlmostEqual(decimal=15,
+          desired=numpy.take(self.n_op_argsfun, indices, axis=iax),
+          actual=evaluable._take(self.op_args, indices, axis=iax))
+
   def test_take_nomask(self):
     for iax, sh in enumerate(self.op_args.shape):
       if sh >= 2:
@@ -418,6 +426,7 @@ _check('unravel', lambda f: evaluable.unravel(f,axis=1,shape=[2,2]), lambda a: a
 _check('inflate', lambda f: evaluable._inflate(f,dofmap=evaluable.Guard([0,3]),length=4,axis=1), lambda a: numpy.concatenate([a[:,:1], numpy.zeros_like(a), a[:,1:]], axis=1), [(4,2,4)])
 _check('inflate-constant', lambda f: evaluable._inflate(f,dofmap=[0,3],length=4,axis=1), lambda a: numpy.concatenate([a[:,:1], numpy.zeros_like(a), a[:,1:]], axis=1), [(4,2,4)])
 _check('inflate-duplicate', lambda f: evaluable.Inflate(f,dofmap=[0,1,0,3],length=4), lambda a: numpy.stack([a[:,0]+a[:,2], a[:,1], numpy.zeros_like(a[:,0]), a[:,3]], axis=1), [(2,4)])
+_check('inflate-block', lambda f: evaluable.Inflate(f,dofmap=[[5,4,3],[2,1,0]],length=6), lambda a: a.ravel()[::-1], [(2,3)])
 _check('take', lambda f: evaluable.Take(f, [0,3,2]), lambda a: a[:,[0,3,2]], [(2,4)])
 _check('take-duplicate', lambda f: evaluable.Take(f, [0,3,0]), lambda a: a[:,[0,3,0]], [(2,4)])
 _check('choose', lambda a, b, c: evaluable.Choose(evaluable.appendaxes(evaluable.Int(a)%2, (3,3)), [b,c]), lambda a, b, c: numpy.choose(a[_,_].astype(int)%2, [b,c]), [(), (3,3), (3,3)])


### PR DESCRIPTION
Commit f60c61d0 introduced a potential regression by removing the inflate/take
simplification for non-constant indices. This patch reintroduces these
simplifications by introducing SwapInflateTake, which generates the required
(potentially duplicate) indices at the time of evaluation.