### PR TITLE
fix nutilshash for nested dataclasses

### DIFF
--- a/nutils/types.py
+++ b/nutils/types.py
@@ -312,7 +312,10 @@ def nutils_hash(data):
     h.update(nutils_hash(data.__self__))
     h.update(nutils_hash(data.__name__))
   elif dataclasses and dataclasses.is_dataclass(t):
-    h.update(nutils_hash(dataclasses.asdict(data, dict_factory=frozendict)))
+    # Note: we cannot use dataclasses.asdict here as its built-in recursion
+    # makes nested dataclass instances indistinguishable from dictionaries.
+    for item in sorted(nutils_hash((field.name, getattr(data, field.name))) for field in dataclasses.fields(t)):
+      h.update(item)
   elif hasattr(data, '__getnewargs__'):
     for arg in data.__getnewargs__():
       h.update(nutils_hash(arg))

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -145,7 +145,7 @@ class nutils_hash(TestCase):
   def test_dataclass(self):
     import dataclasses
     A = dataclasses.make_dataclass('A', [('n', int), ('f', float)])
-    self.assertEqual(nutils.types.nutils_hash(A(n=1, f=2.5)).hex(), 'e655f7e05f7fabbe9c5a5bea79c96e990bcd5988')
+    self.assertEqual(nutils.types.nutils_hash(A(n=1, f=2.5)).hex(), 'daf4235240e897beb9586db3c91663b24e229c52')
 
   def test_type_bool(self):
     self.assertEqual(nutils.types.nutils_hash(bool).hex(), 'feb912889d52d45fcd1e778c427b093a19a1ea78')


### PR DESCRIPTION
This patch fixes the implementation of `types.nutils_hash` for dataclasses with
dataclass attributes. Due to the use of `dataclasses.asdict` these objects were
formerly hashed as dictionaries. One particularly problematic situation was an
attribute of annotated type `typing.Union[mydataclass1, mydataclass2]`, which
resulted in the same hash regardless of the chosen type if the two classes had
matching (or no) attributes. Unfortunately the fix is backwards incompatible,
potentially resulting in cache misses.