### PR TITLE
don't retrieve geom in jump expr. if unnecessary

### DIFF
--- a/nutils/expression.py
+++ b/nutils/expression.py
@@ -706,8 +706,8 @@ class _ExpressionParser:
         geometry_name = self._consume().data
       else:
         geometry_name = self.default_geometry_name
-      geom = self._get_geometry(geometry_name)
       if not omitted_indices and self._next.type == 'indices':
+        geom = self._get_geometry(geometry_name)
         warnings.deprecation('`[f]_i` and `[f]_x_i` are deprecated; use `[f] n({x}_i)` instead'.format(x=geometry_name))
         value *= self._asarray(('normal', _(geom)), self._consume(), geom.shape, False)
     elif self._next.type == '{':


### PR DESCRIPTION
The normal jump, e.g. `[u]_i` as shorthand for `[u] n_i`, existed briefly, but
has been deprecated for a while now. When parsing the jump expresion, we
retrieve the default geometry even if we are not parsing a jump with normal.
This is problematic if we are using a different variable for the geometry, say
`t`, than what the `function.Namespace` assumes to be the default geometry,
normally `x`. This patch defers retrieving the geometry.