### PR TITLE
pytest

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,28 +33,28 @@ jobs:
           if-no-files-found: error
   test:
     needs: build-python-package
-    name: 'Test os: ${{ matrix.os }}, py: ${{ matrix.python-version }}, matrix: ${{ matrix.matrix-backend }}, nprocs: ${{ matrix.nprocs }}, numpy: ${{ matrix.numpy-version }}'
+    name: 'Test os: ${{ matrix.os }}, py: ${{ matrix.python-version }}, matrix: ${{ matrix.matrix-backend }}, nprocs: ${{ matrix.nprocs }}, xdist: ${{ matrix.xdist }}, numpy: ${{ matrix.numpy-version }}'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
           # base
-          - {os: ubuntu-latest , python-version: 3.8, matrix-backend: numpy, nprocs: 1, numpy-version: latest}
+          - {os: ubuntu-latest , python-version: 3.8, matrix-backend: numpy, nprocs: 1, xdist: auto, numpy-version: latest}
           # os
-          - {os: windows-latest, python-version: 3.8, matrix-backend: numpy, nprocs: 1, numpy-version: latest}
-          - {os: macos-latest  , python-version: 3.8, matrix-backend: numpy, nprocs: 1, numpy-version: latest}
+          - {os: windows-latest, python-version: 3.8, matrix-backend: numpy, nprocs: 1, xdist: auto, numpy-version: latest}
+          - {os: macos-latest  , python-version: 3.8, matrix-backend: numpy, nprocs: 1, xdist: auto, numpy-version: latest}
           # python-version
-          - {os: ubuntu-latest , python-version: 3.5, matrix-backend: numpy, nprocs: 1, numpy-version: latest}
-          - {os: ubuntu-latest , python-version: 3.6, matrix-backend: numpy, nprocs: 1, numpy-version: latest}
-          - {os: ubuntu-latest , python-version: 3.7, matrix-backend: numpy, nprocs: 1, numpy-version: latest}
+          - {os: ubuntu-latest , python-version: 3.5, matrix-backend: numpy, nprocs: 1, xdist: 1,    numpy-version: latest}
+          - {os: ubuntu-latest , python-version: 3.6, matrix-backend: numpy, nprocs: 1, xdist: auto, numpy-version: latest}
+          - {os: ubuntu-latest , python-version: 3.7, matrix-backend: numpy, nprocs: 1, xdist: auto, numpy-version: latest}
           # matrix-backend
-          - {os: ubuntu-latest , python-version: 3.8, matrix-backend: scipy, nprocs: 1, numpy-version: latest}
-          - {os: ubuntu-latest , python-version: 3.8, matrix-backend: mkl  , nprocs: 1, numpy-version: latest}
-          - {os: ubuntu-latest , python-version: 3.8, matrix-backend: mkl  , nprocs: 2, numpy-version: latest}
+          - {os: ubuntu-latest , python-version: 3.8, matrix-backend: scipy, nprocs: 1, xdist: auto, numpy-version: latest}
+          - {os: ubuntu-latest , python-version: 3.8, matrix-backend: mkl  , nprocs: 1, xdist: auto, numpy-version: latest}
+          - {os: ubuntu-latest , python-version: 3.8, matrix-backend: mkl  , nprocs: 2, xdist: auto, numpy-version: latest}
           # nprocs
-          - {os: ubuntu-latest , python-version: 3.8, matrix-backend: numpy, nprocs: 2, numpy-version: latest}
+          - {os: ubuntu-latest , python-version: 3.8, matrix-backend: numpy, nprocs: 2, xdist: auto, numpy-version: latest}
           # numpy-version
-          - {os: ubuntu-latest , python-version: 3.8, matrix-backend: numpy, nprocs: 1, numpy-version: 1.15  }
+          - {os: ubuntu-latest , python-version: 3.8, matrix-backend: numpy, nprocs: 1, xdist: auto, numpy-version: 1.15  }
       fail-fast: false
     env:
       NUTILS_MATRIX: ${{ matrix.matrix-backend }}
@@ -83,7 +83,7 @@ jobs:
           _matrix: ${{ matrix.matrix-backend }}
           _numpy: ${{ matrix.numpy-version }}
         run: |
-          _deps="coverage treelog stringly matplotlib pillow meshio"
+          _deps="pytest pytest-cov pytest-xdist treelog stringly matplotlib pillow meshio"
           case "$_os" in
             windows-latest) _deps="$_deps psutil";;
           esac
@@ -106,12 +106,14 @@ jobs:
         run: python -um devtools.gha.get_lib_dir
       - name: Test
         env:
+          PYTEST_ADDOPTS: "--color=yes"
           LD_LIBRARY_PATH: ${{ steps.get-lib-dir.outputs.libdir }}
         run: |
           mkdir testenv
           cp -r examples docs tests .coveragerc testenv
           cd testenv
-          python -um coverage run -m unittest -bq
+          # -n is disabled for python 3.5
+          pytest -n ${{ matrix.xdist }} --cov-report xml --cov=nutils tests/
       - name: Post-process coverage
         run: |
           mv testenv/.coverage .

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -67,6 +67,7 @@ for path in sorted((root/'docs').glob('**/*.rst')):
   if test.examples:
     doctest.addTest(DocTestCase(test, optionflags=_doctest.ELLIPSIS, checker=checker, requires=['matplotlib']))
 
+del DocTestCase
 
 def load_tests(loader, suite, pattern):
   # Ignore default suite (containing `DocTestCase`).


### PR DESCRIPTION
Switch to `pytest` which prints better error message and supports running tests in parallel. With this PR, CI run twice as fast (except for python 3.5, which somehow doesn't work).