### PR TITLE
add function.Custom

### DIFF
--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -526,27 +526,15 @@ class EvaluableConstant(Evaluable):
 
 class Tuple(Evaluable):
 
-  __slots__ = 'items', 'indices'
+  __slots__ = 'items'
 
   @types.apply_annotations
-  def __init__(self, items:tuple): # FIXME: shouldn't all items be Evaluable?
+  def __init__(self, items: types.tuple[strictevaluable]):
     self.items = items
-    args = []
-    indices = []
-    for i, item in enumerate(self.items):
-      if isevaluable(item):
-        args.append(item)
-        indices.append(i)
-    self.indices = tuple(indices)
-    super().__init__(args)
+    super().__init__(items)
 
   def evalf(self, *items):
-    'evaluate'
-
-    T = list(self.items)
-    for index, item in zip(self.indices, items):
-      T[index] = item
-    return tuple(T)
+    return items
 
   def __iter__(self):
     'iterate'

--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -3066,7 +3066,7 @@ class Argument(DerivativeTargetBase):
       return value
 
   def _derivative(self, var, seen):
-    if isinstance(var, Argument) and var._name == self._name:
+    if isinstance(var, Argument) and var._name == self._name and self.dtype == float:
       result = _inflate_scalar(1., self.shape)
       for i, sh in enumerate(self.shape):
         result = diagonalize(result, i, i+self.ndim)
@@ -4056,6 +4056,8 @@ def derivative(func, var, seen=None):
   'derivative'
 
   assert isinstance(var, DerivativeTargetBase), 'invalid derivative target {!r}'.format(var)
+  if var.dtype != float:
+    return Zeros(func.shape + var.shape, dtype=func.dtype)
   if seen is None:
     seen = {}
   func = asarray(func)

--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -497,6 +497,33 @@ class EVALARGS(Evaluable):
 
 EVALARGS = EVALARGS()
 
+class EvaluableConstant(Evaluable):
+  '''Evaluate to the given constant value.
+
+  Parameters
+  ----------
+  value
+      The return value of ``eval``.
+  '''
+
+  __slots__ = 'value'
+
+  def __init__(self, value):
+    self.value = value
+    super().__init__(())
+
+  def evalf(self):
+    return self.value
+
+  @property
+  def _node_details(self):
+    s = repr(self.value)
+    if '\n' in s:
+      s = s.split('\n', 1)[0] + '...'
+    if len(s) > 20:
+      s = s[:17] + '...'
+    return s
+
 class Tuple(Evaluable):
 
   __slots__ = 'items', 'indices'

--- a/nutils/function.py
+++ b/nutils/function.py
@@ -37,7 +37,7 @@ _dtypes = bool, int, float
 class Lowerable(Protocol):
   'Protocol for lowering to :class:`nutils.evaluable.Array`.'
 
-  def lower(self, *, transform_chains: Tuple[evaluable.TransformChain] = (), coordinates: Tuple[evaluable.Array] = ()) -> evaluable.Array:
+  def lower(self, *, transform_chains: Tuple[evaluable.TransformChain, ...] = (), coordinates: Tuple[evaluable.Array, ...] = ()) -> evaluable.Array:
     '''Lower this object to a :class:`nutils.evaluable.Array`.
 
     Parameters
@@ -429,7 +429,7 @@ class _WithoutPoints(Lowerable):
   def __init__(self, __arg: Array) -> None:
     self._arg = __arg
 
-  def lower(self, *, coordinates: Tuple[evaluable.Array] = (), **kwargs):
+  def lower(self, *, coordinates: Tuple[evaluable.Array, ...] = (), **kwargs):
     return self._arg.lower(coordinates=(), **kwargs)
 
 class _Wrapper(Array):
@@ -455,13 +455,13 @@ class _Wrapper(Array):
 
 class _Zeros(Array):
 
-  def lower(self, coordinates: Tuple[evaluable.Array] = (), **kwargs: Any) -> evaluable.Array:
+  def lower(self, coordinates: Tuple[evaluable.Array, ...] = (), **kwargs: Any) -> evaluable.Array:
     shape = coordinates[0].shape[:-1] if coordinates else ()
     return evaluable.Zeros((*shape, *self.shape), self.dtype)
 
 class _Ones(Array):
 
-  def lower(self, coordinates: Tuple[evaluable.Array] = (), **kwargs: Any) -> evaluable.Array:
+  def lower(self, coordinates: Tuple[evaluable.Array, ...] = (), **kwargs: Any) -> evaluable.Array:
     shape = coordinates[0].shape[:-1] if coordinates else ()
     return evaluable.ones((*shape, *self.shape), self.dtype)
 
@@ -548,7 +548,7 @@ class _Opposite(Array):
     self._arg = arg
     super().__init__(arg.shape, arg.dtype)
 
-  def lower(self, *, transform_chains: Tuple[evaluable.TransformChain] = (), coordinates: Tuple[evaluable.Array] = (), **kwargs: Any) -> evaluable.Array:
+  def lower(self, *, transform_chains: Tuple[evaluable.TransformChain, ...] = (), coordinates: Tuple[evaluable.Array, ...] = (), **kwargs: Any) -> evaluable.Array:
     if len(transform_chains) > 2 or len(coordinates) > 2:
       raise ValueError('opposite is not defined if there are more than two transform chains or coordinates')
     return self._arg.lower(transform_chains=transform_chains[::-1], coordinates=coordinates[::-1], **kwargs)
@@ -566,7 +566,7 @@ class _RootCoords(Array):
   def __init__(self, ndims: int) -> None:
     super().__init__((ndims,), float)
 
-  def lower(self, *, transform_chains: Tuple[evaluable.TransformChain] = (), coordinates: Tuple[evaluable.Array] = (), **kwargs) -> evaluable.Array:
+  def lower(self, *, transform_chains: Tuple[evaluable.TransformChain, ...] = (), coordinates: Tuple[evaluable.Array, ...] = (), **kwargs) -> evaluable.Array:
     assert transform_chains and coordinates and len(transform_chains) == len(coordinates)
     return evaluable.ApplyTransforms(transform_chains[0], coordinates[0], self.shape[0])
 
@@ -576,7 +576,7 @@ class _TransformsIndex(Array):
     self._transforms = transforms
     super().__init__((), int)
 
-  def lower(self, *, transform_chains: Tuple[evaluable.TransformChain] = (), **kwargs: Any) -> evaluable.Array:
+  def lower(self, *, transform_chains: Tuple[evaluable.TransformChain, ...] = (), **kwargs: Any) -> evaluable.Array:
     assert transform_chains
     index, tail = evaluable.TransformsIndexWithTail(self._transforms, transform_chains[0])
     return _prepend_points(index, **kwargs)
@@ -587,7 +587,7 @@ class _TransformsCoords(Array):
     self._transforms = transforms
     super().__init__((dim,), int)
 
-  def lower(self, *, transform_chains: Tuple[evaluable.TransformChain] = (), coordinates: Tuple[evaluable.Array] = (), **kwargs: Any) -> evaluable.Array:
+  def lower(self, *, transform_chains: Tuple[evaluable.TransformChain, ...] = (), coordinates: Tuple[evaluable.Array, ...] = (), **kwargs: Any) -> evaluable.Array:
     assert transform_chains and coordinates and len(transform_chains) == len(coordinates)
     index, tail = evaluable.TransformsIndexWithTail(self._transforms, transform_chains[0])
     return evaluable.ApplyTransforms(tail, coordinates[0], self.shape[0])
@@ -616,7 +616,7 @@ class _Jacobian(Array):
     self._geom = geom
     super().__init__((), float)
 
-  def lower(self, *, coordinates: Tuple[evaluable.Array] = (), **kwargs: Any) -> evaluable.Array:
+  def lower(self, *, coordinates: Tuple[evaluable.Array, ...] = (), **kwargs: Any) -> evaluable.Array:
     assert coordinates
     ndims = int(coordinates[0].shape[-1])
     return evaluable.jacobian(self._geom.lower(coordinates=coordinates, **kwargs), ndims)

--- a/nutils/function.py
+++ b/nutils/function.py
@@ -450,6 +450,21 @@ class Array(Lowerable, metaclass=_ArrayMeta):
 def _prepend_points(__arg: evaluable.Array, *, points_shape: Tuple[evaluable.Array, ...] = (), **kwargs: Any) -> evaluable.Array:
   return evaluable.prependaxes(__arg, points_shape)
 
+class _Unlower(Array):
+
+  def __init__(self, array: evaluable.Array, points_shape: Tuple[evaluable.Array, ...], transform_chains: Tuple[evaluable.TransformChain, ...], coordinates: Tuple[evaluable.Array, ...]) -> None:
+    self._array = array
+    self._points_shape = points_shape
+    self._transform_chains = transform_chains
+    self._coordinates = coordinates
+    shape = tuple(n.__index__() for n in array.shape[len(points_shape):])
+    super().__init__(shape=shape, dtype=array.dtype)
+
+  def lower(self, *, points_shape: Tuple[evaluable.Array, ...] = (), transform_chains: Tuple[evaluable.TransformChain, ...] = (), coordinates: Tuple[evaluable.Array, ...] = ()):
+    if self._points_shape != points_shape or self._transform_chains != transform_chains or self._coordinates != coordinates:
+      raise ValueError('_Unlower must be lowered with the same arguments as those with which it is instantiated.')
+    return self._array
+
 class _WithoutPoints(Lowerable):
 
   def __init__(self, __arg: Array) -> None:

--- a/nutils/sample.py
+++ b/nutils/sample.py
@@ -147,13 +147,15 @@ class Sample(types.Singleton):
 
     raise NotImplementedError
 
-  def _lower_for_loop(self, func, **kwargs):
+  def _lower_for_loop(self, func, *, points_shape=(), **kwargs):
     if kwargs.pop('transform_chains', None) or kwargs.pop('coordinates', None):
       raise ValueError('nested integrals or samples are not yet supported')
     ielem = evaluable.loop_index('_ielem', self.nelems)
+    coordinates = self.points.get_evaluable_coords(ielem)
     return ielem, func.lower(**kwargs,
+      points_shape=points_shape+coordinates.shape[:-1],
       transform_chains=tuple(evaluable.TransformChainFromSequence(t, ielem) for t in self.transforms),
-      coordinates=(self.points.get_evaluable_coords(ielem),) * len(self.transforms))
+      coordinates=(evaluable.prependaxes(coordinates, points_shape),) * len(self.transforms))
 
   @util.positional_only
   @util.single_or_multiple

--- a/nutils/sparse.py
+++ b/nutils/sparse.py
@@ -253,7 +253,7 @@ def block(datas):
     out['value'] = data['value']
     for idim, iblock in enumerate(blockidx):
       outindex = out['index']['i'+str(idim)]
-      numpy.add(data['index']['i'+str(idim)], blocksizes[idim][:iblock].sum(), out=outindex, dtype=outindex.dtype)
+      numpy.add(data['index']['i'+str(idim)], blocksizes[idim][:iblock].sum(), out=outindex, dtype=outindex.dtype.type)
       # NOTE: Specifying the dtype is necessary because Numpy apparently does
       # not follow the out argument automatically, defaulting instead to a
       # dtype that may be to small to contain the result of the addition.

--- a/nutils/types.py
+++ b/nutils/types.py
@@ -1400,4 +1400,80 @@ def _isimmutable(obj):
     or isinstance(obj, frozendict) and all(_isimmutable(value) for value in obj.values()) \
     or isinstance(obj, numpy.ndarray) and not any(base.flags.writeable for base in _array_bases(obj))
 
+class _hashable_function_wrapper:
+
+  def __init__(self, wrapped, identifier):
+    self.__nutils_hash__ = nutils_hash(('hashable_function', identifier))
+    functools.update_wrapper(self, wrapped)
+
+  def __call__(*args, **kwargs):
+    return args[0].__wrapped__(*args[1:], **kwargs)
+
+  def __get__(self, instance, owner):
+    return self
+
+  def __hash__(self):
+    return hash(self.__nutils_hash__)
+
+  def __eq__(self, other):
+    return type(self) is type(other) and self.__nutils_hash__ == other.__nutils_hash__
+
+def hashable_function(identifier):
+  '''Decorator that wraps the decorated function and adds a Nutils hash.
+
+  Return a decorator that wraps the decorated function and adds a Nutils hash
+  based solely on the given ``identifier``. The identifier can be anything that has a
+  Nutils hash. The identifier should represent the behavior of the function and
+  should be changed when the behavior of the function changes.
+
+  If used on methods, this decorator behaves like :func:`staticmethod`.
+
+  Examples
+  --------
+
+  Make some function ``func`` hashable:
+
+  >>> @hashable_function('func v1')
+  ... def func(a, b):
+  ...   return a + b
+  ...
+
+  The Nutils hash can be obtained by calling ``nutils_hash`` on ``func``:
+
+  >>> nutils_hash(func).hex()
+  'b7fed72647f6a88dd3ce3808b2710eede7d7b5a5'
+
+  Note that the hash is based solely on the identifier passed to the decorator.
+  If we create another function ``other`` with the same identifier as ``func``,
+  then both have the same hash, despite returning different values.
+
+  >>> @hashable_function('func v1')
+  ... def other(a, b):
+  ...   return a * b
+  ...
+  >>> nutils_hash(other) == nutils_hash(func)
+  True
+  >>> func(1, 2) == other(1, 2)
+  False
+
+  The decorator can also be applied on methods:
+
+  >>> class Spam:
+  ...   @hashable_function('Spam.eggs v1')
+  ...   def eggs(a, b):
+  ...     # NOTE: `self` is absent because `hashable_function` behaves like `staticmethod`.
+  ...     return a + b
+  ...
+
+  The hash of ``eggs`` accessed via the class or an instance is the same:
+
+  >>> spam = Spam()
+  >>> nutils_hash(Spam.eggs).hex()
+  'dfdbb0ce20b617b17c3b854c23b2b9f7deb94cc6'
+  >>> nutils_hash(spam.eggs).hex()
+  'dfdbb0ce20b617b17c3b854c23b2b9f7deb94cc6'
+  '''
+
+  return functools.partial(_hashable_function_wrapper, identifier=identifier)
+
 # vim:sw=2:sts=2:et

--- a/tests/test_evaluable.py
+++ b/tests/test_evaluable.py
@@ -1038,3 +1038,22 @@ class combine_loop_concatenates(TestCase):
     self.assertNotIn(A_, L2._Evaluable__args)
     desired = evaluable.Tuple((A_, evaluable.ArrayFromTuple(L2, 0, (9,), int)))
     self.assertEqual(actual, desired)
+
+class EvaluableConstant(TestCase):
+
+  def test_evalf(self):
+    self.assertEqual(evaluable.EvaluableConstant(1).evalf(), 1)
+    self.assertEqual(evaluable.EvaluableConstant('1').evalf(), '1')
+
+  def test_node_details(self):
+
+    class Test:
+      def __init__(self, s):
+        self.s = s
+      def __repr__(self):
+        return self.s
+
+    self.assertEqual(evaluable.EvaluableConstant(Test('some string'))._node_details, 'some string')
+    self.assertEqual(evaluable.EvaluableConstant(Test('a very long string that should be abbreviated'))._node_details, 'a very long strin...')
+    self.assertEqual(evaluable.EvaluableConstant(Test('a string with\nmultiple lines'))._node_details, 'a string with...')
+    self.assertEqual(evaluable.EvaluableConstant(Test('a very long string with\nmultiple lines'))._node_details, 'a very long strin...')

--- a/tests/test_evaluable.py
+++ b/tests/test_evaluable.py
@@ -766,6 +766,12 @@ class elemwise(TestCase):
   def test_var_shape(self):
     self.assertElemwise(numpy.arange(i*j).reshape(i,j) for i, j in ((1,2),(2,4)))
 
+class derivative(TestCase):
+
+  def test_int(self):
+    arg = evaluable.Argument('arg', (2,), int)
+    self.assertEqual(evaluable.derivative(arg[None], arg), evaluable.Zeros((1,2,2), int))
+
 class jacobian(TestCase):
 
   def setUp(self):

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -270,6 +270,16 @@ _check('Array_getitem_ellipsis_scalar_newaxis', lambda a: function.Array.cast(a)
 _check('add_T', lambda a: function.add_T(a, (1, 2)), lambda a: a + a.transpose((0,2,1)), [(5,2,2)], dtype=int)
 _check('Array_add_T', lambda a: function.Array.cast(a).add_T((1, 2)), lambda a: a + a.transpose((0,2,1)), [(5,2,2)], dtype=int)
 
+class Unlower(TestCase):
+
+  def test(self):
+    e = evaluable.Argument('arg', (2,3,4,5), int)
+    f = function._Unlower(e, (2,3), (), ())
+    self.assertEqual(f.shape, (4,5))
+    self.assertEqual(f.dtype, int)
+    self.assertEqual(f.lower(points_shape=(2,3), transform_chains=(), coordinates=()), e)
+    with self.assertRaises(ValueError):
+      f.lower(points_shape=(3,4), transform_chains=(), coordinates=())
 
 class broadcasting(TestCase):
 

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -1068,7 +1068,8 @@ class CommonBasis:
   def test_lower(self):
     ref = element.PointReference() if self.basis.coords.shape[0] == 0 else element.LineReference()**self.basis.coords.shape[0]
     points = ref.getpoints('bezier', 4)
-    lowered = self.basis.lower(transform_chains=(evaluable.TransformChainFromSequence(self.checktransforms, evaluable.Argument('ielem', (), int)),), coordinates=(evaluable.Constant(points.coords),))
+    coordinates = evaluable.Constant(points.coords)
+    lowered = self.basis.lower(points_shape=coordinates.shape[:-1], transform_chains=(evaluable.TransformChainFromSequence(self.checktransforms, evaluable.Argument('ielem', (), int)),), coordinates=(coordinates,))
     with _builtin_warnings.catch_warnings():
       _builtin_warnings.simplefilter('ignore', category=evaluable.ExpensiveEvaluationWarning)
       for ielem in range(self.checknelems):

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -10,7 +10,8 @@ class TopologyAssertions:
     interfaces = domain.interfaces
     bmask = numpy.zeros(len(boundary), dtype=int)
     imask = numpy.zeros(len(interfaces), dtype=int)
-    lowered_geom = geom.lower(transform_chains=(evaluable.SelectChain(0),), coordinates=(evaluable.Points(evaluable.NPoints(), boundary.ndims),))
+    coordinates = evaluable.Points(evaluable.NPoints(), boundary.ndims)
+    lowered_geom = geom.lower(points_shape=coordinates.shape[:-1], transform_chains=(evaluable.SelectChain(0),), coordinates=(coordinates,))
     for ielem, ioppelems in enumerate(domain.connectivity):
       for iedge, ioppelem in enumerate(ioppelems):
         etrans, eref = domain.references[ielem].edges[iedge]

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1068,4 +1068,45 @@ class lru_cache(TestCase):
     del a
     self.assertIs(r(), None)
 
+class hashable_function(TestCase):
+
+  def test_hash(self):
+    def func(): pass
+    self.assertEqual(nutils.types.nutils_hash(nutils.types.hashable_function('a')(func)).hex(), 'b4e9593d1bbb26059a5c6665b4a3bc15cf7a0d91')
+    self.assertEqual(nutils.types.nutils_hash(nutils.types.hashable_function('b')(func)).hex(), '4b0f56560e408925fc65fabc2ba220ed7d62e10d')
+
+  def test_equality(self):
+
+    @nutils.types.hashable_function('a')
+    def f(): pass
+
+    @nutils.types.hashable_function('a')
+    def g(): pass
+
+    @nutils.types.hashable_function('b')
+    def h(): pass
+
+    self.assertEqual(f, g)
+    self.assertEqual(hash(f), hash(g))
+    self.assertNotEqual(f, h)
+
+  def test_function(self):
+
+    @nutils.types.hashable_function('f')
+    def f(arg):
+      return arg
+
+    self.assertEqual(f(1), 1)
+
+  def test_method(self):
+
+    class Test:
+
+      @nutils.types.hashable_function('f')
+      def f(arg):
+        return arg
+
+    self.assertEqual(Test.f(1), 1)
+    self.assertEqual(Test().f(1), 1)
+
 # vim:sw=2:sts=2:et


### PR DESCRIPTION
Since `evaluable` has been split off of `function` it is more difficult for end users to implement their own `function.Array` as they also have to implement an `evaluable.Array`. To lessen the burden, this PR introduces `function.Custom`: a base class that automatically lowers to an `evaluable.Array` with `evalf` and `derivative` taken from the implementation of `function.Custom` and clones three broadcasting functions from NumPy that could be useful when implementing a custom function.
