### PR TITLE
make function.Array.shape a tuple of ints

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,22 @@ features in inverse chronological order.
 New in v7.0 (in development)
 ----------------------------
 
+- Changed: function.Array shape must be constant
+
+  Resulting from to the function/evaluable split introduced in #574, variable
+  length axes such as relating to integration points or sparsity can stay
+  confined to the evaluable layer. In order to benefit from this situation and
+  improve compatibility with Numpy's arrays, :class:`nutils.function.Array`
+  objects are henceforth limited to constant shapes. Additionally:
+
+  * The sparsity construct ``nutils.function.inflate`` has been removed;
+  * The :func:`nutils.function.Elemwise` function requires all element arrays
+    to be of the same shape, and its remaining use has been deprecated in
+    favor of :func:`nutils.function.get`;
+  * Aligning with Numpy's API, :func:`nutils.function.concatenate` no longer
+    automatically broadcasts its arguments, but instead demands that all
+    dimensions except for the concatenation axis match exactly.
+
 - Changed: locate arguments
 
   The :func:`nutils.topology.Topology.locate` method now allows ``tol`` to be

--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -3377,24 +3377,6 @@ class PolyOuterProduct(Array):
   def evalf(self, left, right):
     return numeric.poly_outer_product(left, right)
 
-class AssertEqual(Array):
-
-  def __init__(self, *args):
-    self._args = args
-    assert len(set(arg.shape for arg in args)) == 1
-    assert len(set(arg.dtype for arg in args)) == 1
-    super().__init__(self._args, shape=args[0].shape, dtype=args[0].dtype)
-
-  def evalf(self, *args):
-    arg0 = args[0]
-    for arg in args[1:]:
-      numpy.testing.assert_array_equal(arg, arg0)
-    return arg0
-
-  def _simplified(self):
-    if len(set(self._args)) == 1:
-      return self._args[0]
-
 class RevolutionAngle(Array):
   '''
   Pseudo coordinates of a :class:`nutils.topology.RevolutionTopology`.

--- a/tests/test_finitecell.py
+++ b/tests/test_finitecell.py
@@ -395,7 +395,7 @@ class partialtrim(TestCase):
     self.assertEqual(set(self.topoB.boundary['trimmed'].transforms), set(self.topoA.boundary['trimmed'].opposites))
 
   def test_opposites(self):
-    ielem = function.Elemwise(numpy.arange(4), self.topo.f_index, dtype=int)
+    ielem = self.topo.f_index
     sampleA = self.topoA.boundary['trimmed'].sample('uniform', 1)
     sampleB = self.topoB.boundary['trimmed'].sample('uniform', 1)
     self.assertEqual(set(sampleB.eval(ielem)), {0,1})


### PR DESCRIPTION
Resulting from to the function/evaluable split introduced in #574, variable length axes such as relating to integration points or sparsity can stay confined to the evaluable layer. In order to benefit from this situation and improve compatibility with Numpy's arrays, function.Array objects are henceforth limited to constant shapes. Additionally, function.inflate has been removed, and function.Elemwise has been deprecated in favour of function.get.

Fixes #629.