### PR TITLE
Stricter evaluables

### DIFF
--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -118,7 +118,10 @@ def equalshape(N:asshape, M:asshape):
   time.
   '''
 
-  assert len(N) == len(M)
+  if N == M:
+    return True
+  if len(N) != len(M):
+    return False
   retval = True
   for eq in map(equalindex, N, M):
     if eq == False:

--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -1539,12 +1539,8 @@ class Product(Array):
 
   def _derivative(self, var, seen):
     grad = derivative(self.func, var, seen)
-    funcs = stack([util.product(self.func[...,j] for j in range(self.func.shape[-1]) if i != j) for i in range(self.func.shape[-1])], axis=self.ndim)
+    funcs = Product(insertaxis(self.func, -2, self.func.shape[-1]) + Diagonalize(1 - self.func)) # replace diagonal entries by 1
     return (grad * appendaxes(funcs, var.shape)).sum(self.ndim)
-
-    ## this is a cleaner form, but is invalid if self.func contains zero values:
-    #ext = (...,)+(_,)*len(shape)
-    #return self[ext] * (derivative(self.func,var,shape,seen) / self.func[ext]).sum(self.ndim)
 
   def _take(self, indices, axis):
     return Product(_take(self.func, indices, axis))

--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -4161,7 +4161,7 @@ def appendaxes(func, shape):
 
   func = asarray(func)
   for n in shape:
-    func = insertaxis(func, func.ndim, n)
+    func = InsertAxis(func, n)
   return func
 
 def loop_index(name, length):

--- a/nutils/function.py
+++ b/nutils/function.py
@@ -3152,7 +3152,8 @@ class StructuredBasis(Basis):
       length = evaluable.get(lengths_i, 0, index_i)
       offset = evaluable.get(offsets_i, 0, index_i)
       dofs_i = (evaluable.Range(length) + offset) % ndofs_i
-      dofs = dofs_i if dofs is None else evaluable.ravel(evaluable.insertaxis(dofs * ndofs_i, 1, length) + dofs_i, axis=0)
+      dofs = dofs_i if dofs is None else evaluable.ravel(evaluable.insertaxis(dofs * ndofs_i, 1, length)
+                                                       + evaluable.insertaxis(dofs_i, 0, dofs.shape[0]), axis=0)
     coeffs = functools.reduce(evaluable.PolyOuterProduct,
       [evaluable.Elemwise(coeffs_i, index_i, float) for coeffs_i, index_i in zip(self._coeffs, indices)])
     return dofs, coeffs

--- a/tests/test_evaluable.py
+++ b/tests/test_evaluable.py
@@ -385,7 +385,7 @@ _check('cosh', evaluable.cosh, numpy.cosh, [(4,)])
 _check('sinh', evaluable.sinh, numpy.sinh, [(4,)])
 _check('abs', evaluable.abs, numpy.abs, [(4,)])
 _check('sign', evaluable.sign, numpy.sign, [(4,4)], zerograd=True)
-_check('power', evaluable.power, numpy.power, [(4,1),(1,4)], low=0)
+_check('power', evaluable.power, numpy.power, [(4,4),(4,4)], low=0)
 _check('negative', evaluable.negative, numpy.negative, [(4,)])
 _check('reciprocal', evaluable.reciprocal, numpy.reciprocal, [(4,)], low=-2, high=-1)
 _check('arcsin', evaluable.arcsin, numpy.arcsin, [(4,)])
@@ -405,24 +405,24 @@ _check('determinant141', lambda a: evaluable.determinant(a,(0,2)), lambda a: num
 _check('determinant434', lambda a: evaluable.determinant(a,(0,2)), lambda a: numpy.linalg.det(a.swapaxes(0,1)), [(4,3,4)])
 _check('determinant4433', lambda a: evaluable.determinant(a,(2,3)), lambda a: numpy.linalg.det(a), [(4,4,3,3)])
 _check('determinant200', lambda a: evaluable.determinant(a,(1,2)), lambda a: numpy.linalg.det(a) if a.shape[-1] else numpy.ones(a.shape[:-2], float), [(2,0,0)], zerograd=True)
-_check('inverse141', lambda a: evaluable.inverse(a+evaluable.Diagonalize(evaluable.ones([1]))[:,None],(0,2)), lambda a: numpy.linalg.inv(a.swapaxes(0,1)+numpy.eye(1)).swapaxes(0,1), [(1,4,1)])
-_check('inverse434', lambda a: evaluable.inverse(a+5*evaluable.Diagonalize(evaluable.ones([4]))[:,None],(0,2)), lambda a: numpy.linalg.inv(a.swapaxes(0,1)+5*numpy.eye(4)).swapaxes(0,1), [(4,3,4)])
-_check('inverse4422', lambda a: evaluable.inverse(a+evaluable.Diagonalize(evaluable.ones([2]))), lambda a: numpy.linalg.inv(a+numpy.eye(2)), [(4,4,2,2)])
+_check('inverse141', lambda a: evaluable.inverse(a+1,(0,2)), lambda a: numpy.linalg.inv(a.swapaxes(0,1)+1).swapaxes(0,1), [(1,4,1)])
+_check('inverse434', lambda a: evaluable.inverse(a+5*evaluable.insertaxis(evaluable.Diagonalize(evaluable.ones([4])), 1, 3),(0,2)), lambda a: numpy.linalg.inv(a.swapaxes(0,1)+5*numpy.eye(4)).swapaxes(0,1), [(4,3,4)])
+_check('inverse4422', lambda a: evaluable.inverse(a+evaluable.prependaxes(evaluable.Diagonalize(evaluable.ones([2])), (4,4))), lambda a: numpy.linalg.inv(a+numpy.eye(2)), [(4,4,2,2)])
 _check('repeat', lambda a: evaluable.repeat(a,3,1), lambda a: numpy.repeat(a,3,1), [(4,1,4)])
 _check('diagonalize', lambda a: evaluable.diagonalize(a,1,3), lambda a: numeric.diagonalize(a,1,3), [(4,4,4,4)])
-_check('multiply', evaluable.multiply, numpy.multiply, [(4,1),(4,4)])
+_check('multiply', evaluable.multiply, numpy.multiply, [(4,4),(4,4)])
 _check('dot', lambda a,b: evaluable.dot(a,b,axes=1), lambda a,b: (a*b).sum(1), [(4,2,4),(4,2,4)])
-_check('divide', evaluable.divide, lambda a, b: a * b**-1, [(4,4),(1,4)], low=-2, high=-1)
+_check('divide', evaluable.divide, lambda a, b: a * b**-1, [(4,4),(4,4)], low=-2, high=-1)
 _check('divide2', lambda a: evaluable.asarray(a)/2, lambda a: a/2, [(4,1)])
-_check('add', evaluable.add, numpy.add, [(4,1),(1,4)])
-_check('subtract', evaluable.subtract, numpy.subtract, [(4,1),(1,4)])
-_check('dot2', lambda a,b: evaluable.multiply(a,b).sum(-2), lambda a,b: (a*b).sum(-2), [(4,2,4),(1,2,4)])
+_check('add', evaluable.add, numpy.add, [(4,4),(4,4)])
+_check('subtract', evaluable.subtract, numpy.subtract, [(4,4),(4,4)])
+_check('dot2', lambda a,b: evaluable.multiply(a,b).sum(-2), lambda a,b: (a*b).sum(-2), [(4,2,4),(4,2,4)])
 _check('min', lambda a,b: evaluable.Minimum(a,b), numpy.minimum, [(4,4),(4,4)])
 _check('max', lambda a,b: evaluable.Maximum(a,b), numpy.maximum, [(4,4),(4,4)])
-_check('equal', lambda a,b: evaluable.Equal(*evaluable._numpy_align(a,b)), numpy.equal, [(4,1),(1,4)], zerograd=True)
-_check('greater', lambda a,b: evaluable.Greater(*evaluable._numpy_align(a,b)), numpy.greater, [(4,1),(1,4)], zerograd=True)
-_check('less', lambda a,b: evaluable.Less(*evaluable._numpy_align(a,b)), numpy.less, [(4,1),(1,4)], zerograd=True)
-_check('arctan2', evaluable.arctan2, numpy.arctan2, [(4,1),(1,4)])
+_check('equal', evaluable.Equal, numpy.equal, [(4,4),(4,4)], zerograd=True)
+_check('greater', evaluable.Greater, numpy.greater, [(4,4),(4,4)], zerograd=True)
+_check('less', evaluable.Less, numpy.less, [(4,4),(4,4)], zerograd=True)
+_check('arctan2', evaluable.arctan2, numpy.arctan2, [(4,4),(4,4)])
 _check('stack', lambda a,b: evaluable.stack([a,b], 0), lambda a,b: numpy.concatenate([a[_,:],b[_,:]], axis=0), [(4,),(4,)])
 _check('eig', lambda a: evaluable.eig(a+a.swapaxes(0,1),symmetric=True)[1], lambda a: numpy.linalg.eigh(a+a.swapaxes(0,1))[1], [(4,4)], hasgrad=False)
 _check('trignormal', lambda a: evaluable.TrigNormal(a), lambda a: numpy.array([numpy.cos(a), numpy.sin(a)]), [()])
@@ -705,7 +705,8 @@ class commutativity(TestCase):
     self.assertEqual(evaluable.dot(self.A, self.B, axes=[0]), evaluable.dot(self.B, self.A, axes=[0]))
 
   def test_combined(self):
-    self.assertEqual(evaluable.add(self.A, self.B) * evaluable.dot(self.A, self.B, axes=[0]), evaluable.dot(self.B, self.A, axes=[0]) * evaluable.add(self.B, self.A))
+    self.assertEqual(evaluable.add(self.A, self.B) * evaluable.insertaxis(evaluable.dot(self.A, self.B, axes=[0]), 0, 2),
+                     evaluable.insertaxis(evaluable.dot(self.B, self.A, axes=[0]), 0, 2) * evaluable.add(self.B, self.A))
 
 
 class sampled(TestCase):
@@ -862,18 +863,16 @@ class asciitree(TestCase):
 
   @unittest.skipIf(sys.version_info < (3, 6), 'test requires dicts maintaining insertion order')
   def test_asciitree(self):
-    f = evaluable.Sin(evaluable.Inflate(1, evaluable.Zeros((), int), 2)**evaluable.Diagonalize(evaluable.Argument('arg', (2,))))
+    f = evaluable.Sin((evaluable.Zeros((), int))**evaluable.Diagonalize(evaluable.Argument('arg', (2,))))
     self.assertEqual(f.asciitree(richoutput=True),
                      '%0 = Sin; f:a2,a2\n'
                      '└ %1 = Power; f:a2,a2\n'
-                     '  ├ %2 = Transpose; 1,0; i:i2,s2\n'
-                     '  │ └ %3 = InsertAxis; i:s2,i2\n'
-                     '  │   ├ %4 = Inflate; i:s2\n'
-                     '  │   │ ├ 1\n'
-                     '  │   │ ├ 0\n'
-                     '  │   │ └ 2\n'
-                     '  │   └ 2\n'
-                     '  └ %5 = Diagonalize; f:d2,d2\n'
+                     '  ├ %2 = InsertAxis; i:i2,i2\n'
+                     '  │ ├ %3 = InsertAxis; i:i2\n'
+                     '  │ │ ├ 0\n'
+                     '  │ │ └ 2\n'
+                     '  │ └ 2\n'
+                     '  └ %4 = Diagonalize; f:d2,d2\n'
                      '    └ Argument; arg; f:a2\n')
 
   @unittest.skipIf(sys.version_info < (3, 6), 'test requires dicts maintaining insertion order')

--- a/tests/test_evaluable.py
+++ b/tests/test_evaluable.py
@@ -771,7 +771,7 @@ class derivative(TestCase):
 
   def test_int(self):
     arg = evaluable.Argument('arg', (2,), int)
-    self.assertEqual(evaluable.derivative(arg[None], arg), evaluable.Zeros((1,2,2), int))
+    self.assertEqual(evaluable.derivative(evaluable.insertaxis(arg, 0, 1), arg), evaluable.Zeros((1,2,2), int))
 
 class jacobian(TestCase):
 


### PR DESCRIPTION
In the developing split of `function` as the Numpy-like array frontend and `evaluable` as the stricter computational backend, this PR removes automatic broadcasting, fancy slicing, and other Numpy-like behaviour from the evaluable module.