### PR TITLE
remove axis properties

### DIFF
--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -996,7 +996,7 @@ class Array(Evaluable, metaclass=_ArrayMeta):
   __mod__  = lambda self, other: mod(self, other)
   __int__ = __index__
   __str__ = __repr__ = lambda self: '{}.{}<{}>'.format(type(self).__module__, type(self).__name__, self._shape_str(form=str))
-  _shape_str = lambda self, form: '{}:{}'.format(self.dtype.__name__[0] if hasattr(self, 'dtype') else '?', ','.join(map(form, self._axes)) if hasattr(self, '_axes') else '?')
+  _shape_str = lambda self, form: '{}:{}'.format(self.dtype.__name__[0] if hasattr(self, 'dtype') else '?', ','.join(str(int(length)) if length.isconstant else '?' for length in self.shape) if hasattr(self, 'shape') else '?')
 
   sum = sum
   prod = product

--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -3178,6 +3178,10 @@ class Ravel(Array):
   def _inflate(self, dofmap, length, axis):
     if axis < self.ndim-dofmap.ndim:
       return Ravel(_inflate(self.func, dofmap, length, axis))
+    elif dofmap.ndim == 0:
+      return ravel(Inflate(self.func, dofmap, length), self.ndim-1)
+    else:
+      return _inflate(self.func, Unravel(dofmap, *self.func.shape[-2:]), length, axis)
 
   def _diagonalize(self, axis):
     if axis != self.ndim-1:

--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -3146,8 +3146,7 @@ class Ravel(Array):
     return Ravel(Multiply([self.func, Unravel(other, *self.func.shape[-2:])]))
 
   def _add(self, other):
-    if isinstance(other, Ravel) and equalshape(other.func.shape[-2:], self.func.shape[-2:]):
-      return Ravel(Add([self.func, other.func]))
+    return Ravel(self.func + Unravel(other, *self.func.shape[-2:]))
 
   def _sum(self, axis):
     if axis == self.ndim-1:

--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -1721,13 +1721,9 @@ class Multiply(Array):
 
   def _add(self, other):
     func1, func2 = self.funcs
-    if other == func1:
-      return Multiply([func1, Add([func2, ones_like(func2)])])
-    if other == func2:
-      return Multiply([func2, Add([func1, ones_like(func1)])])
-    if isinstance(other, Multiply) and not self.funcs.isdisjoint(other.funcs):
-      f = next(iter(self.funcs & other.funcs))
-      return Multiply([f, Add(self.funcs + other.funcs - [f,f])])
+    if isinstance(other, Multiply):
+      for common in self.funcs & other.funcs:
+        return common * Add(self.funcs + other.funcs - [common, common])
 
   def _determinant(self, axis1, axis2):
     func1, func2 = self.funcs

--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -1830,9 +1830,7 @@ class Multiply(Array):
 
   def _intbounds_impl(self):
     func1, func2 = self.funcs
-    lower1, upper1 = func1._intbounds
-    lower2, upper2 = func2._intbounds
-    extrema = lower1 * lower2, lower1 * upper2, upper1 * lower2, upper1 * upper2
+    extrema = [b1 and b2 and b1 * b2 for b1 in func1._intbounds for b2 in func2._intbounds]
     return min(extrema), max(extrema)
 
 class Add(Array):

--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -1376,6 +1376,8 @@ class Transpose(Array):
   def _takediag(self, axis1, axis2):
     assert axis1 < axis2
     orig1, orig2 = sorted(self.axes[axis] for axis in [axis1, axis2])
+    if orig1 == self.ndim-2:
+      return Transpose(TakeDiag(self.func), (*self.axes[:axis1], *self.axes[axis1+1:axis2], *self.axes[axis2+1:], self.ndim-2))
     trytakediag = self.func._takediag(orig1, orig2)
     if trytakediag is not None:
       return Transpose(trytakediag, [ax-(ax>orig1)-(ax>orig2) for ax in self.axes[:axis1] + self.axes[axis1+1:axis2] + self.axes[axis2+1:]] + [self.ndim-2])

--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -3820,12 +3820,8 @@ def zeros_like(arr):
   return zeros(arr.shape, arr.dtype)
 
 def isuniform(arg, value):
-  while isinstance(arg, (InsertAxis, Transpose)):
-    arg = arg.func
-  if isinstance(arg, Constant) and arg.ndim == 0:
-    return arg.value[()] == value
-  else:
-    return False
+  unaligned, where = unalign(arg)
+  return not where and isinstance(unaligned, Constant) and unaligned.value[()] == value
 
 def ones(shape, dtype=float):
   return _inflate_scalar(numpy.ones((), dtype=dtype), shape)

--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -1764,9 +1764,6 @@ class Multiply(Array):
       return align(unaligned1 * unaligned2, where, self.shape)
     for axis1, axis2, *other in map(sorted, func1._diagonals or func2._diagonals):
       return diagonalize(Multiply(takediag(func, axis1, axis2) for func in self.funcs), axis1, axis2)
-    for i, axis in enumerate(self._axes):
-      if isinstance(axis, Raveled):
-        return ravel(Multiply(unravel(func, i, axis.shape) for func in self.funcs), i)
     for i, parts in func1._inflations:
       return util.sum(_inflate(f * _take(func2, dofmap, i), dofmap, self.shape[i], i) for dofmap, f in parts.items())
     for i, parts in func2._inflations:

--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -2734,7 +2734,7 @@ class Inflate(Array):
     if axis2 == self.ndim-1:
       func = _take(self.func, self.dofmap, axis1)
       for i in range(self.dofmap.ndim):
-        func = _takediag(func, axis1, axis2-i)
+        func = _takediag(func, axis1, axis2+self.dofmap.ndim-1-i)
       return Inflate(func, self.dofmap, self.length)
     else:
       return _inflate(_takediag(self.func, axis1, axis2), self.dofmap, self.length, self.ndim-3)

--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -911,11 +911,6 @@ class Array(Evaluable, metaclass=_ArrayMeta):
       raise TypeError('len() of unsized object')
     return self.shape[0]
 
-  def __iter__(self):
-    if not self.shape:
-      raise TypeError('iteration over a 0-d array')
-    return (self[i,...] for i in range(self.shape[0]))
-
   def __index__(self):
     try:
       index = self.__index

--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -3161,6 +3161,9 @@ class Ravel(Array):
     assert axis1 < axis2
     if axis2 <= self.ndim-2:
       return ravel(_takediag(self.func, axis1, axis2), self.ndim-3)
+    else:
+      unraveled = unravel(self.func, axis1, self.func.shape[-2:])
+      return Ravel(_takediag(_takediag(unraveled, axis1, -2), axis1, -2))
 
   def _take(self, index, axis):
     if axis != self.ndim-1:

--- a/nutils/testing.py
+++ b/nutils/testing.py
@@ -237,7 +237,7 @@ ContextTestCase = TestCase
 
 class FloatNeighborhoodOutputChecker(doctest.OutputChecker):
 
-  posnum = '(?:[0-9]+|[0-9]+[.]|[.][0-9]+)(?:e[+-]?[0-9]+)?'
+  posnum = '(?:[0-9]+[.][0-9]*|[.][0-9]+|[0-9]+)(?:e[+-]?[0-9]+)?'
   re_spread = re.compile('\\b((?:-?{posnum}|array[(][^()]*[)])±{posnum})\\b'.format(posnum=posnum))
 
   def check_output(self, want, got, optionflags):

--- a/tests/test_evaluable.py
+++ b/tests/test_evaluable.py
@@ -816,15 +816,15 @@ class asciitree(TestCase):
   def test_asciitree(self):
     f = evaluable.Sin((evaluable.Zeros((), int))**evaluable.Diagonalize(evaluable.Argument('arg', (2,))))
     self.assertEqual(f.asciitree(richoutput=True),
-                     '%0 = Sin; f:a2,a2\n'
-                     '└ %1 = Power; f:a2,a2\n'
-                     '  ├ %2 = InsertAxis; i:i2,i2\n'
-                     '  │ ├ %3 = InsertAxis; i:i2\n'
+                     '%0 = Sin; f:2,2\n'
+                     '└ %1 = Power; f:2,2\n'
+                     '  ├ %2 = InsertAxis; i:2,2\n'
+                     '  │ ├ %3 = InsertAxis; i:2\n'
                      '  │ │ ├ 0\n'
                      '  │ │ └ 2\n'
                      '  │ └ 2\n'
-                     '  └ %4 = Diagonalize; f:d2,d2\n'
-                     '    └ Argument; arg; f:a2\n')
+                     '  └ %4 = Diagonalize; f:2,2\n'
+                     '    └ Argument; arg; f:2\n')
 
   @unittest.skipIf(sys.version_info < (3, 6), 'test requires dicts maintaining insertion order')
   def test_loop_sum(self):
@@ -850,8 +850,8 @@ class asciitree(TestCase):
                      'NODES\n'
                      '%B0 = LoopConcatenate\n'
                      '├ shape[0] = %A1 = Take; i:\n'
-                     '│ ├ %A2 = _SizesToOffsets; i:a3\n'
-                     '│ │ └ %A3 = InsertAxis; i:i2\n'
+                     '│ ├ %A2 = _SizesToOffsets; i:3\n'
+                     '│ │ └ %A3 = InsertAxis; i:2\n'
                      '│ │   ├ 1\n'
                      '│ │   └ 2\n'
                      '│ └ 2\n'
@@ -864,7 +864,7 @@ class asciitree(TestCase):
                      '│ └ %B7 = Add; i:\n'
                      '│   ├ %B5\n'
                      '│   └ 1\n'
-                     '└ func = %B8 = InsertAxis; i:i1\n'
+                     '└ func = %B8 = InsertAxis; i:1\n'
                      '  ├ %B5\n'
                      '  └ 1\n')
 
@@ -879,8 +879,8 @@ class asciitree(TestCase):
                      'NODES\n'
                      '%B0 = LoopConcatenate\n'
                      '├ shape[0] = %A1 = Take; i:\n'
-                     '│ ├ %A2 = _SizesToOffsets; i:a3\n'
-                     '│ │ └ %A3 = InsertAxis; i:i2\n'
+                     '│ ├ %A2 = _SizesToOffsets; i:3\n'
+                     '│ │ └ %A3 = InsertAxis; i:2\n'
                      '│ │   ├ 1\n'
                      '│ │   └ 2\n'
                      '│ └ 2\n'
@@ -893,7 +893,7 @@ class asciitree(TestCase):
                      '│ └ %B7 = Add; i:\n'
                      '│   ├ %B5\n'
                      '│   └ 1\n'
-                     '└ func = %B8 = InsertAxis; i:i1\n'
+                     '└ func = %B8 = InsertAxis; i:1\n'
                      '  ├ %B5\n'
                      '  └ 1\n')
 

--- a/tests/test_evaluable.py
+++ b/tests/test_evaluable.py
@@ -306,22 +306,6 @@ class check(TestCase):
         actual=evaluable.loop_concatenate(self.op(*args), index),
         desired=n_op_argsfun)
 
-  def test_desparsify(self):
-    args = []
-    for arg in self.args:
-      for i in range(arg.ndim):
-        arg = evaluable._inflate(arg, evaluable.Guard(numpy.arange(int(arg.shape[i]))), arg.shape[i], i)
-      args.append(arg)
-    op_args = self.op(*args).simplified
-    evalargs = dict(zip(self.arg_names, self.arg_values))
-    for axis, prop in enumerate(op_args._axes):
-      if isinstance(prop, evaluable.Sparse):
-        actual = numpy.zeros_like(self.n_op_argsfun)
-        for ind, f in op_args._desparsify(axis):
-          _ind = ind.eval(**evalargs)
-          numpy.add.at(actual, (slice(None),)*(axis)+(_ind,), f.eval(**evalargs))
-        self.assertArrayAlmostEqual(actual, self.n_op_argsfun, decimal=15)
-
   @parametrize.enable_if(lambda hasgrad, **kwargs: hasgrad)
   def test_derivative(self):
     eps = 1e-4

--- a/tests/test_evaluable.py
+++ b/tests/test_evaluable.py
@@ -637,55 +637,6 @@ class intbounds(TestCase):
   def test_normdim_mixed(self):
     self.assertEqual(evaluable.NormDim(self.S('l', 4, 5), self.S('i', -3, 2))._intbounds, (0, 4))
 
-class blocks(TestCase):
-
-  def setUp(self):
-    super().setUp()
-    _builtin_warnings.simplefilter('ignore', evaluable.ExpensiveEvaluationWarning)
-
-  def test_multiply_equal(self):
-    ((i,), f), = evaluable.multiply(evaluable._inflate([1,2], dofmap=[0,2], length=3, axis=0), evaluable._inflate([3,4], dofmap=[0,2], length=3, axis=0)).blocks
-    self.assertAllEqual(i.eval(), [0,2])
-    self.assertAllEqual(f.eval(), [1*3,2*4])
-
-  def test_multiply_embedded(self):
-    ((i,), f), = evaluable.multiply([1,2,3], evaluable._inflate([4,5], dofmap=[0,2], length=3, axis=0)).blocks
-    self.assertAllEqual(i.eval(), [0,2])
-    self.assertAllEqual(f.eval(), [1*4,3*5])
-
-  def test_multiply_overlapping(self):
-    ((i,), f), = evaluable.multiply(evaluable._inflate([1,2], dofmap=[0,1], length=3, axis=0), evaluable._inflate([3,4], dofmap=[1,2], length=3, axis=0)).blocks
-    self.assertAllEqual(i.eval(), [1])
-    self.assertAllEqual(f.eval(), [2*3])
-
-  def test_multiply_disjoint(self):
-    blocks = evaluable.multiply(evaluable._inflate([1,2], dofmap=[0,2], length=4, axis=0), evaluable._inflate([3,4], dofmap=[1,3], length=4, axis=0)).blocks
-    self.assertEqual(blocks, ())
-
-  def test_takediag(self):
-    ((i,), f), = evaluable.takediag([[1,2,3],[4,5,6],[7,8,9]]).blocks
-    self.assertAllEqual(i.eval(), [0,1,2])
-    self.assertAllEqual(f.eval(), [1,5,9])
-
-  def test_takediag_embedded_axis(self):
-    ((i,), f), = evaluable.takediag(evaluable._inflate([[1,2,3],[4,5,6]], dofmap=[0,2], length=3, axis=0)).blocks
-    self.assertAllEqual(i.eval(), [0,2])
-    self.assertAllEqual(f.eval(), [1,6])
-
-  def test_takediag_embedded_rmaxis(self):
-    ((i,), f), = evaluable.takediag(evaluable._inflate([[1,2],[3,4],[5,6]], dofmap=[0,2], length=3, axis=1)).blocks
-    self.assertAllEqual(i.eval(), [0,2])
-    self.assertAllEqual(f.eval(), [1,6])
-
-  def test_takediag_overlapping(self):
-    ((i,), f), = evaluable.takediag(evaluable._inflate(evaluable._inflate([[1,2],[3,4]], dofmap=[0,1], length=3, axis=0), dofmap=[1,2], length=3, axis=1)).blocks
-    self.assertAllEqual(i.eval(), [1])
-    self.assertAllEqual(f.eval(), [3])
-
-  def test_takediag_disjoint(self):
-    blocks = evaluable.takediag(evaluable._inflate(evaluable._inflate([[1,2],[3,4]], dofmap=[0,2], length=4, axis=0), dofmap=[1,3], length=4, axis=1)).blocks
-    self.assertEqual(blocks, ())
-
 
 class commutativity(TestCase):
 

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -649,3 +649,25 @@ common(
   topo=topology.DisjointUnionTopology([mesh.rectilinear([8])[0][l:r] for l, r in [[0,2],[4,6]]]),
   hasboundary=False,
   hasbasis=False)
+
+
+class project(TestCase):
+
+  def setUp(self):
+    self.topo, self.geom = mesh.rectilinear([8])
+    self.basis = self.topo.basis('std', degree=1)
+
+  def test_lsqr(self):
+    exact = numpy.sin(numpy.arange(9))
+    projected = self.topo.project(self.basis.dot(exact), onto=self.basis, geometry=self.geom, ptype='lsqr', degree=2)
+    self.assertAllAlmostEqual(exact, projected)
+
+  def test_nodal(self):
+    exact = numpy.sin(numpy.arange(9))
+    projected = self.topo.project(self.basis.dot(exact), onto=self.basis, geometry=self.geom, ptype='nodal', degree=2)
+    self.assertAllAlmostEqual(exact, projected)
+
+  def test_convolute(self):
+    exact = numpy.repeat(numpy.pi, 9)
+    projected = self.topo.project(self.basis.dot(exact), onto=self.basis, geometry=self.geom, ptype='convolute', degree=2)
+    self.assertAllAlmostEqual(exact, projected)


### PR DESCRIPTION
The `axes` attribute assigned dimension properties such as sparsity or insertedness, which is required for certain simplifications. Setting these properties in every constructor is however very expensive. This PR effectively makes the attribute lazy by querying the inverse operation (`_desparsify`, `_uninsert`) and testing for a nonzero return value.