### PR TITLE
fix reordering points in func @ sample

### DIFF
--- a/nutils/sample.py
+++ b/nutils/sample.py
@@ -816,7 +816,8 @@ class _ReorderPoints(function.Array):
 
   def lower(self, points_shape: _PointsShape, transform_chains: _TransformChainsMap, coordinates: _CoordinatesMap) -> evaluable.Array:
     func = self._func.lower(points_shape, transform_chains, coordinates)
-    return evaluable.take(func, self._indices, axis=len(points_shape))
+    axis = len(points_shape)
+    return evaluable.Transpose.from_end(evaluable.Inflate(evaluable.Transpose.to_end(func, axis), self._indices, self._indices.shape[0]), axis)
 
 class _Basis(function.Array):
 

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -882,14 +882,14 @@ class locate(TestCase):
     self.geom = geom
 
   def test(self):
-    target = numpy.array([(.2,.3), (.1,.9), (0,1)])
+    target = numpy.array([(.2,.3), (.1,.9), (0,1), (.1,.3)])
     sample = self.domain.locate(self.geom, target, eps=1e-15, tol=1e-12)
     located = sample.eval(self.geom)
     self.assertAllAlmostEqual(located, target)
 
   @parametrize.enable_if(lambda etype, mode, **kwargs: etype != 'square' or mode == 'nonlinear')
   def test_maxdist(self):
-    target = numpy.array([(.2,.3), (.1,.9), (0,1)])
+    target = numpy.array([(.2,.3), (.1,.9), (0,1), (.1,.3)])
     with self.assertRaises(topology.LocateError):
       self.domain.locate(self.geom, [(0, .3)], eps=1e-15, tol=1e-12, maxdist=.001)
     sample = self.domain.locate(self.geom, target, eps=1e-15, tol=1e-12, maxdist=.5)


### PR DESCRIPTION
In commit 6266ca9a the `sample._AtSample` function has been split into a
concatenate and reorder. The latter is omitted when the indices are trivial:
`[0,1,2,...]`. The reorder function has been implemented using `Take` instead
of `Inflate`, because the former is slightly cheaper than the latter. However,
we forget about inverting the indices, which is required for `Take` and much
more expensive than `Inflate`. This patch replaces `Take` with `Inflate` and
adds and amends several unit tests.