### PR TITLE
fix sample.eval_integrals_sparse

### DIFF
--- a/nutils/sample.py
+++ b/nutils/sample.py
@@ -757,8 +757,8 @@ def eval_integrals_sparse(*integrals: evaluable.AsEvaluableArray, **arguments: M
   results : :class:`tuple` of arrays and/or :class:`nutils.matrix.Matrix` objects.
   '''
 
-  warnings.deprecation('sample.eval_integrals_sparse is deprecated, use function.eval_sparse instead')
-  return function.eval_sparse(integrals, **arguments)
+  warnings.deprecation('sample.eval_integrals_sparse is deprecated, use evaluable.eval_sparse instead')
+  return evaluable.eval_sparse(integrals, **argdict(arguments))
 
 def _convert(data: numpy.ndarray, inplace: bool = False) -> Union[numpy.ndarray, matrix.Matrix]:
   '''Convert a two-dimensional sparse object to an appropriate object.

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -409,6 +409,15 @@ class integral(TestCase):
       self.topo.integral('basis_n d:x' @ self.ns, degree=2).eval(),
       places=15)
 
+  def test_eval_integrals(self):
+    v, = sample.eval_integrals(self.topo.integral('basis_n d:x' @ self.ns, degree=2))
+    self.assertAllAlmostEqual(self.topo.integrate('basis_n d:x' @ self.ns, degree=2), v, places=15)
+
+  def test_eval_integrals_sparse(self):
+    with self.assertWarns(warnings.NutilsDeprecationWarning):
+      data, = sample.eval_integrals_sparse(self.topo.integral('basis_n d:x' @ self.ns, degree=2))
+    self.assertAllAlmostEqual(self.topo.integrate('basis_n d:x' @ self.ns, degree=2), sparse.toarray(data), places=15)
+
   def test_args(self):
     self.assertAlmostEqual(
       self.topo.integrate('v d:x' @ self.ns, degree=2, arguments=dict(lhs=self.lhs)),


### PR DESCRIPTION
This patch fixes a bug that was introduced in commit a202366 of #653, which
introduced evaluable.eval_sparse and deprecated sample.eval_integrals_sparse.
In doing so, the method was erroneously changed to dispatch to
function.eval_sparse, a location that had been temporarily considered but was
ultimately rejected. The bug was not noticed because all unit tests were
updated to use the new method directly; two tests are added to correct this.