### PR TITLE
remove MKL_THREADING_LAYER override

### DIFF
--- a/nutils/matrix/_mkl.py
+++ b/nutils/matrix/_mkl.py
@@ -29,8 +29,6 @@ libmkl = util.loadlib(linux='libmkl_rt.so', darwin='libmkl_rt.dylib', win32='mkl
 if not libmkl:
   raise BackendNotAvailable('the Intel MKL matrix backend requires libmkl to be installed (try: pip install mkl)')
 
-os.environ.setdefault('MKL_THREADING_LAYER', 'TBB')
-
 def assemble(data, index, shape):
   # In the increments below the output dtype is set to int32 not only to avoid
   # an additional allocation, but crucially also to avoid truncation in case


### PR DESCRIPTION
MS Windows is reported to have issues with MKL's TBB threading layer. Since
this value is set in _mkl.py, this means scripts will fail on Windows with
OSError [WinError] unless they use cli.run (which changes the threading layer
to sequential). To fix scripts that do not make use of cli.run, this patch
remove the override of the MKL_THREADING_LAYER variable.

Fixes #647.