### PR TITLE
fix doc of param timestep of solver.thetamethod

### DIFF
--- a/nutils/solver.py
+++ b/nutils/solver.py
@@ -683,7 +683,7 @@ class thetamethod(cache.Recursion, length=1, version=1):
     residual : :class:`nutils.evaluable.AsEvaluableArray`
     inertia : :class:`nutils.evaluable.AsEvaluableArray`
     timestep : :class:`float`
-        Initial time step, will scale up as residual decreases
+        The time step.
     lhs0 : :class:`numpy.ndarray`
         Coefficient vector, starting point of the iterative procedure.
     theta : :class:`float`


### PR DESCRIPTION
The docstring of parameter timestep of the thetamethod incorrectly
states that the timestep changes based on the residual.