### PR TITLE
fix gradient of function.Custom

### DIFF
--- a/nutils/function.py
+++ b/nutils/function.py
@@ -784,7 +784,7 @@ class _CustomEvaluable(evaluable.Array):
         result = evaluable.Zeros(self.shape + var.shape, dtype=self.dtype)
         unlowered_args = tuple(_Unlower(arg, self.spaces, self.function_arguments, self.lower_args) if isinstance(arg, evaluable.Array) else arg.value for arg in self.args)
         for iarg, arg in enumerate(self.args):
-            if not isinstance(arg, evaluable.Array) or arg.dtype in (bool, int) or var not in arg.dependencies and var != arg:
+            if not isinstance(arg, evaluable.Array) or arg.dtype in (bool, int) or var not in arg.arguments and var != arg:
                 continue
             fpd = Array.cast(self.custom_partial_derivative(iarg, *unlowered_args))
             fpd_expected_shape = tuple(n.__index__() for n in self.shape[self.points_dim:] + arg.shape[self.points_dim:])

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -590,6 +590,20 @@ class Custom(TestCase):
         with self.assertRaisesRegex(ValueError, '`partial_derivative` to argument 0 returned an array with shape'):
             Test((arg,), (5,), float).derivative(arg).as_evaluable_array
 
+    def test_grad(self):
+
+        class Test(function.Custom):
+            def eval(arg):
+                return arg
+            @staticmethod
+            def partial_derivative(iarg, arg):
+                return function.ones(arg.shape)
+
+        topo, geom = mesh.line(3)
+        smpl = topo.sample('bezier', 2)
+        test = Test((geom**2,), geom.shape, float)
+        self.assertAllAlmostEqual(*smpl.eval([2 * geom, function.grad(test, geom)]))
+
 
 class broadcasting(TestCase):
 


### PR DESCRIPTION
The class `function.Custom` lowers to a class that implements `evaluable.Array.derivative` in terms of partial derivatives of the loweree: for all arguments that are instances of `evaluable.Array` with dtype `float` or `complex` the `function.Custom.partial_derivative` method is called and the result is dotted with the derivative of the argument to the derivative target.

To increase the performance of the construction of the derivative, arguments that do not depend on the derivative target are skipped. The dependency test, however, incorrectly uses the `Evaluable.dependencies` attribute, which does not contain virtual derivative targets, in particular the root coordinates (`function._root_derivative_target`). The effect of this bug is that derivatives of lowered `function.Custom` objects to a virtual derivative target become zero.

This patch fixes this problem by testing for existence of a derivative target using the `Evaluable.arguments` attribute and adds a unittest.