### PR TITLE
do not log 'finish' upon error

### DIFF
--- a/nutils/_util.py
+++ b/nutils/_util.py
@@ -439,11 +439,9 @@ def timeit():
 
     t0 = datetime.datetime.now()
     treelog.info(f'start {t0:%Y-%m-%d %H:%M:%S}')
-    try:
-        yield
-    finally:
-        te = datetime.datetime.now()
-        treelog.info(f'finish {te:%Y-%m-%d %H:%M:%S}, elapsed {format_timedelta(te-t0)}')
+    yield
+    te = datetime.datetime.now()
+    treelog.info(f'finish {te:%Y-%m-%d %H:%M:%S}, elapsed {format_timedelta(te-t0)}')
 
 
 class timer:


### PR DESCRIPTION
This patch removes timeit's "finish" message out of the finally clause, which caused applications to appear finished even though they failed on exception.