### PR TITLE
improve log_traceback

### DIFF
--- a/nutils/_util.py
+++ b/nutils/_util.py
@@ -563,9 +563,18 @@ def log_traceback(gracefulexit: bool = True):
         raise
     except:
         exc = traceback.TracebackException(*sys.exc_info())
-        treelog.error(''.join(exc.format_exception_only()).rstrip())
-        for s in exc.stack.format():
-            treelog.debug(s.rstrip())
+        prefix = ''
+        while True:
+            treelog.error(prefix + ''.join(exc.format_exception_only()).rstrip())
+            treelog.debug('Traceback (most recent call first):\n' + ''.join(reversed(exc.stack.format())).rstrip())
+            if exc.__cause__ is not None:
+                exc = exc.__cause__
+                prefix = '.. caused by '
+            elif exc.__context__ is not None and not exc.__suppress_context__:
+                exc = exc.__context__
+                prefix = '.. while handling '
+            else:
+                break
         raise SystemExit(1)
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -295,11 +295,31 @@ class log_arguments(TestCase):
 class log_traceback(TestCase):
 
     def test(self):
-
         with self.assertRaises(SystemExit), self.assertLogs('nutils') as cm, util.log_traceback(gracefulexit=True):
             1/0
-
         self.assertEqual(cm.output, ['ERROR:nutils:ZeroDivisionError: division by zero'])
+
+    def test_cause(self):
+        with self.assertRaises(SystemExit), self.assertLogs('nutils') as cm, util.log_traceback(gracefulexit=True):
+            try:
+                1/0
+            except Exception as e:
+                raise RuntimeError('something went wrong') from e
+        self.assertEqual(cm.output, ['ERROR:nutils:RuntimeError: something went wrong',
+            'ERROR:nutils:.. caused by ZeroDivisionError: division by zero'])
+
+    def test_context(self):
+        with self.assertRaises(SystemExit), self.assertLogs('nutils') as cm, util.log_traceback(gracefulexit=True):
+            try:
+                1/0
+            except Exception:
+                raise RuntimeError('something went wrong')
+        self.assertEqual(cm.output, ['ERROR:nutils:RuntimeError: something went wrong',
+            'ERROR:nutils:.. while handling ZeroDivisionError: division by zero'])
+
+    def test_nograce(self):
+        with self.assertRaises(ZeroDivisionError), util.log_traceback(gracefulexit=False):
+            1/0
 
 
 class signal_handler(TestCase):


### PR DESCRIPTION
Logged tracebacks used to follow cause and context until the rewrite of #701 removed it. This patch restores this useful functionality.