### PR TITLE
make Array.cast more efficient

### DIFF
--- a/nutils/_util.py
+++ b/nutils/_util.py
@@ -32,6 +32,12 @@ def cumsum(seq):
         offset += i
 
 
+def deep_reduce(f, a):
+    '''Recursively apply function to lists or tuples, depth first.'''
+
+    return f([deep_reduce(f, v) for v in a]) if isinstance(a, (list, tuple)) else a
+
+
 def gather(items):
     gathered = collections.defaultdict(list)
     # NOTE: defaultdict is subclass of dict, so it maintains the insertion order

--- a/nutils/function.py
+++ b/nutils/function.py
@@ -156,7 +156,7 @@ class Array(numpy.lib.mixins.NDArrayOperatorsMixin, metaclass=_ArrayMeta):
         if method != '__call__' or ufunc not in HANDLED_FUNCTIONS:
             return NotImplemented
         try:
-            arrays = [v if isinstance(v, (Array, bool, int, float, complex, numpy.ndarray)) else Array.cast(v) for v in inputs]
+            arrays = [Array.cast(v) for v in inputs]
         except ValueError:
             return NotImplemented
         return HANDLED_FUNCTIONS[ufunc](*arrays, **kwargs)

--- a/nutils/function.py
+++ b/nutils/function.py
@@ -3920,8 +3920,11 @@ def Namespace(*args, **kwargs):
 
 
 def _is_unit_scalar(v):
-    T = type(v)
-    return T in _dtypes and v == T(1)
+    'Test if Array.cast(v) == _Constant(True / 1 / 1. / 1+0j)'
+
+    return isinstance(v, (bool, int, float, complex)) and v == 1 \
+        or isinstance(v, numpy.ndarray) and v.ndim == 0 and v == 1 \
+        or isinstance(v, _Constant) and v.ndim == 0 and numpy.asarray(v._value) == 1
 
 
 HANDLED_FUNCTIONS = {}

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -17,8 +17,12 @@ class Array(TestCase):
             function.Array.cast([1.2, 2.3], dtype=int)
 
     def test_cast_invalid_argument(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "cannot convert '132' to Array: unsupported data type"):
             function.Array.cast('132')
+
+    def test_cast_different_shapes(self):
+        with self.assertRaisesRegex(ValueError, 'cannot convert \[\[1, 2, 3\], \[4, 5\]\] to Array: all input arrays must have the same shape'):
+            function.Array.cast([[1,2,3],[4,5]])
 
     def test_ndim(self):
         self.assertEqual(function.Argument('a', (2, 3)).ndim, 2)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -358,3 +358,12 @@ class add_htmllog(TestCase):
             with util.add_htmllog(outdir=outdir):
                 treelog.info('hi there')
             self.assertTrue(os.path.isfile(os.path.join(outdir, 'log.html')))
+
+
+class deep_reduce(TestCase):
+
+    def test(self):
+        L = 1, 2, [3, (4, 5), 6], 7
+        self.assertEqual(util.deep_reduce(min, L), 1)
+        self.assertEqual(util.deep_reduce(max, L), 7)
+        self.assertEqual(util.deep_reduce(sum, L), 28)


### PR DESCRIPTION
This PR changes the way in which nested data is cast to an Array. The main reason for the change is that the opportunistic call to _Constant was potentially expensive, as the call to asarray (via arraydata) could lead to expensive iteration (casting and stacking results) before concluding that the resulting object is not actually numerical. To prevent this, we need to be able to determine a priori whether an object can successfully be made _Constant. However, as valid data can take the form of deeply nested data structures, this test is not trivial. This patch solves the problem by stacking the data in a depth-first fashion, and conclude by either accepting the result if it is Array, or otherwise wrapping it in a _Constant. At this stage all nested data is taken care of by stack, and a cheap test for allowable objects remains.