### PR TITLE
Avoid unnecessary copy in creation of arraydata

### DIFF
--- a/nutils/types.py
+++ b/nutils/types.py
@@ -753,7 +753,7 @@ class arraydata(Singleton):
             return arg
         array = numpy.asarray(arg)
         dtype = dict(b=bool, u=int, i=int, f=float, c=complex)[array.dtype.kind]
-        return super().__new__(cls, dtype, array.shape, array.astype(dtype).tobytes())
+        return super().__new__(cls, dtype, array.shape, array.astype(dtype, copy=False).tobytes())
 
     def __init__(self, dtype, shape, bytes):
         self.dtype = dtype


### PR DESCRIPTION
This patch adds copy=None to astype in the arraydata constructor, which used to always make a copy of the source array just before tobytes would copy it again. In the new form, the first copy is made only if the source dtype is not the platform default, e.g. int32 instead of int64.