### PR TITLE
descriptor-only evalf debug mode

### DIFF
--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -2338,7 +2338,7 @@ class Sin(Pointwise):
 class Tan(Pointwise):
     'Tangent, element-wise.'
     __slots__ = ()
-    evalf = numpy.tan
+    evalf = staticmethod(numpy.tan)
     complex_deriv = lambda x: Cos(x)**-2,
     return_type = lambda T: complex if T == complex else float
 
@@ -2370,7 +2370,7 @@ class ArcTan(Pointwise):
 class CosH(Pointwise):
     'Hyperbolic cosine, element-wise.'
     __slots__ = ()
-    evalf = numpy.cosh
+    evalf = staticmethod(numpy.cosh)
     complex_deriv = lambda x: SinH(x),
     return_type = lambda T: complex if T == complex else float
 

--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -822,10 +822,10 @@ if debug_flags.sparse:
 if debug_flags.evalf:
     class _evalf_checker:
         def __init__(self, orig):
-            self.evalf_obj = getattr(orig, '__get__', lambda *args: orig)
+            self.orig = orig
 
         def __get__(self, instance, owner):
-            evalf = self.evalf_obj(instance, owner)
+            evalf = self.orig.__get__(instance, owner)
 
             @functools.wraps(evalf)
             def evalf_with_check(*args, **kwargs):

--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -824,6 +824,10 @@ if debug_flags.evalf:
         def __init__(self, orig):
             self.orig = orig
 
+        def __set_name__(self, owner, name):
+            if hasattr(self.orig, '__set_name__'):
+                self.orig.__set_name__(owner, name)
+
         def __get__(self, instance, owner):
             evalf = self.orig.__get__(instance, owner)
 


### PR DESCRIPTION
With PR #734 all (but two) `evalf` implementations support the descriptor protocol. This PR removes support for descriptorless `evalf`s in the `evalf` debug wrapper and adds support for descriptors that require calling `__set_name__` before being `__get__`.