### PR TITLE
remove EvaluationError

### DIFF
--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -2733,7 +2733,8 @@ class Sampled(Array):
 
     @staticmethod
     def evalf(points, expect):
-        assert numpy.equal(points, expect).all(), 'illegal point set'
+        if points.shape != expect.shape or not numpy.equal(points, expect).all():
+            raise ValueError('points do not correspond to original sample')
         return numpy.eye(len(points))
 
 

--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -385,7 +385,8 @@ class Evaluable(types.Singleton):
         except KeyboardInterrupt:
             raise
         except Exception as e:
-            raise EvaluationError(self, values) from e
+            log.error(self._format_stack(values, e))
+            raise
         else:
             return values[-1]
 
@@ -398,7 +399,8 @@ class Evaluable(types.Singleton):
         except KeyboardInterrupt:
             raise
         except Exception as e:
-            raise EvaluationError(self, values) from e
+            log.error(self._format_stack(values, e))
+            raise
         else:
             return values[-1]
 
@@ -521,11 +523,6 @@ class Evaluable(types.Singleton):
                 self = replace(lambda key: replacements.get(key) if isinstance(key, LoopConcatenate) else None, recursive=False, depthfirst=False)(self)
             else:
                 return self
-
-
-class EvaluationError(Exception):
-    def __init__(self, f, values):
-        super().__init__(f._format_stack(values, 'ERROR'))
 
 
 class EVALARGS(Evaluable):
@@ -4059,7 +4056,7 @@ class _LoopIndex(Argument):
     def __str__(self):
         try:
             length = self.length.__index__()
-        except EvaluationError:
+        except:
             length = '?'
         return 'LoopIndex({}, length={})'.format(self._name, length)
 

--- a/tests/test_finitecell.py
+++ b/tests/test_finitecell.py
@@ -74,11 +74,11 @@ class trimmedboundary(TestCase):
         gauss1 = trimmed.sample('gauss', 1)
         leftbasis = self.domain0[:1].basis('std', degree=1)
         self.assertTrue(numpy.any(gauss1.eval(leftbasis)))
-        with self.assertRaises(evaluable.EvaluationError):
+        with self.assertRaises(ValueError):
             gauss1.eval(function.opposite(leftbasis))
         rightbasis = self.domain0[1:].basis('std', degree=1)
         self.assertTrue(numpy.any(gauss1.eval(function.opposite(rightbasis))))
-        with self.assertRaises(evaluable.EvaluationError):
+        with self.assertRaises(ValueError):
             gauss1.eval(rightbasis)
 
 

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -568,7 +568,7 @@ class Custom(TestCase):
             def evalf():
                 return numpy.array([1, 2, 3])
 
-        with self.assertRaises(evaluable.EvaluationError):
+        with self.assertRaises(ValueError):
             Test((), (), int).eval()
 
     def test_pointwise_singleton_expansion(self):
@@ -670,7 +670,7 @@ class sampled(TestCase):
         self.assertAllAlmostEqual(diff, 0)
 
     def test_pointset(self):
-        with self.assertRaises(evaluable.EvaluationError):
+        with self.assertRaises(ValueError):
             self.domain.integrate(self.f_sampled, ischeme='uniform2')
 
 

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -446,7 +446,7 @@ class rectilinear(TestCase):
         func = self.geom[0]**2 - self.geom[1]**2
         values = self.gauss2.eval(func)
         sampled = self.gauss2.asfunction(values)
-        with self.assertRaises(evaluable.EvaluationError):
+        with self.assertRaises(ValueError):
             self.bezier2.eval(sampled)
         self.assertAllEqual(self.gauss2.eval(sampled), values)
         arg = function.Argument('dofs', [2, 3])


### PR DESCRIPTION
Remove the evaluable.EvaluationError exception type, which presented debugging difficulties by shielding the actual point of failure from PDB. In the new situation, the evaluation stack is logged at error level prior to reraising the original exception.