### PR TITLE
Fix unit tests failing with Numpy 1.24.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -96,7 +96,7 @@ jobs:
           python -um pip install "$_wheel[import_gmsh]"
       - name: Install Scipy
         if: ${{ matrix.matrix-backend == 'scipy' }}
-        run: python -um pip install --upgrade --upgrade-strategy eager scipy
+        run: python -um pip install --upgrade scipy
       - name: Configure MKL
         if: ${{ matrix.matrix-backend == 'mkl' }}
         run: |

--- a/nutils/numeric.py
+++ b/nutils/numeric.py
@@ -243,7 +243,7 @@ def inv(A):
 
 isarray = lambda a: isinstance(a, numpy.ndarray)
 isboolarray = lambda a: isarray(a) and a.dtype == bool
-isbool = lambda a: isboolarray(a) and a.ndim == 0 or type(a) == bool
+isbool = lambda a: isboolarray(a) and a.ndim == 0 or isinstance(a, (bool, numpy.bool_))
 isint = lambda a: isinstance(a, numbers.Integral)
 isnumber = lambda a: isinstance(a, numbers.Number)
 isintarray = lambda a: isarray(a) and numpy.issubdtype(a.dtype, numpy.integer)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = '~=3.7'
 dependencies = [
     "appdirs~=1.0",
     "bottombar~=2.0.2",
-    "numpy>=1.17",
+    "numpy>=1.17,<1.24",
     "psutil~=5.0",
     "stringly",
     "treelog>=1.0b5",

--- a/tests/test_numeric.py
+++ b/tests/test_numeric.py
@@ -160,7 +160,7 @@ class istype(TestCase):
 
     def test_isbool(self):
         self.assertTrue(numeric.isbool(True))
-        self.assertTrue(numeric.isbool(numpy.bool(True)))
+        self.assertTrue(numeric.isbool(numpy.bool_(True)))
         self.assertTrue(numeric.isbool(numpy.array(True)))
         self.assertFalse(numeric.isbool(numpy.array([True])))
 


### PR DESCRIPTION
This PR aims to fix the unit tests that broke with the release of Numpy version 1.24.0 earlier today (though no mention of it on the website as yet). The failing workflow of the master branch is https://github.com/evalf/nutils/actions/runs/3714405319.