### PR TITLE
Pull inserted axes through TransformCoords

### DIFF
--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -3898,6 +3898,10 @@ class TransformCoords(Array):
     def _simplified(self):
         if self._target == self._source:
             return self._coords
+        cax = self.ndim - 1
+        coords, where = unalign(self._coords, naxes=cax)
+        if len(where) < cax:
+            return align(TransformCoords(self._target, self._source, self._index, coords), (*where, cax), self.shape)
 
 
 class TransformIndex(Array):


### PR DESCRIPTION
This patch adds a simplification to the TransformCoords operation that removes inserted axes from its input coordinates and reapplies them to the result. Besides improving the efficiency of the transformation itself, this simplification also exposes insertion structure to any operation following it such as PolyVal, which can then benefit from a similar simplification.