### PR TITLE
fix basis multipatch topology (bpo)

### DIFF
--- a/nutils/topology.py
+++ b/nutils/topology.py
@@ -3134,15 +3134,9 @@ class MultipatchTopology(TransformChainsTopology):
         if patchcontinuous:
             # build merge mapping: merge common boundary dofs (from low to high)
             pairs = itertools.chain(*(zip(*dofs) for dofs in commonboundarydofs.values() if len(dofs) > 1))
-            merge = numpy.arange(dofcount)
-            for dofs in sorted(pairs):
-                merge[list(dofs)] = merge[list(dofs)].min()
-            assert all(numpy.all(merge[a] == merge[b]) for a, *B in commonboundarydofs.values() for b in B), 'something went wrong is merging interface dofs; this should not have happened'
-            # build renumber mapping: renumber remaining dofs consecutively, starting at 0
-            remainder, renumber = numpy.unique(merge, return_inverse=True)
+            renumber, dofcount = util.merge_index_map(dofcount, pairs)
             # apply mappings
             dofmap = tuple(types.frozenarray(renumber[v], copy=False) for v in dofmap)
-            dofcount = len(remainder)
 
         return function.PlainBasis(coeffs, dofmap, dofcount, self.f_index, self.f_coords)
 

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -1127,6 +1127,18 @@ class multipatch_L(TestCase):
             self.assertEqual(opp1, interfaces2.opposites[i2])
 
 
+class multipatch_misc(TestCase):
+
+    def test_basis_merge_dofs(self):
+        patches = (0, 4, 2, 5), (9, 1, 5, 3), (2, 5, 6, 7), (5, 3, 7, 8)
+        domain, geom = mesh.multipatch(patches=patches, nelems=1)
+        basis = domain.basis('spline', 1)
+        actual = domain.sample('bezier', 2).eval(basis)
+        desired = numpy.zeros((16, 10))
+        desired[numpy.arange(16), [0, 1, 2, 3, 4, 5, 3, 6, 2, 3, 7, 8, 3, 6, 8, 9]] = 1
+        numpy.testing.assert_allclose(actual, desired)
+
+
 class multipatch_errors(TestCase):
 
     def test_reverse(self):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -239,3 +239,26 @@ class cached_property(TestCase):
         self.assertEqual(a.x, 'x')
         self.assertEqual(a.x, 'x')
         self.assertEqual(a.counter, 1)
+
+
+class merge_index_map(TestCase):
+
+    def test_empty_merge_sets(self):
+        index_map, count = util.merge_index_map(4, [])
+        self.assertEqual(index_map.tolist(), [0, 1, 2, 3])
+        self.assertEqual(count, 4)
+
+    def test_merge_set_one(self):
+        index_map, count = util.merge_index_map(4, [[1]])
+        self.assertEqual(index_map.tolist(), [0, 1, 2, 3])
+        self.assertEqual(count, 4)
+
+    def test_multihop1(self):
+        index_map, count = util.merge_index_map(4, [[0, 2], [1, 3], [0, 3]])
+        self.assertEqual(index_map.tolist(), [0, 0, 0, 0])
+        self.assertEqual(count, 1)
+
+    def test_multihop2(self):
+        index_map, count = util.merge_index_map(4, [[2, 3], [1, 2], [0, 3]])
+        self.assertEqual(index_map.tolist(), [0, 0, 0, 0])
+        self.assertEqual(count, 1)


### PR DESCRIPTION
This PR fixes creating a basis on a `MultipatchTopology` with C^0 continuity at the patch interfaces. In addition, this PR deduplicates code for merging dofs.