### PR TITLE
Locate missing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,14 @@ The following overview lists user facing changes as well as newly added
 features in inverse chronological order.
 
 
+FIXED: locate points on trimmed topologies with the skip_missing flag set
+
+The `locate` method has a `skip_missing` argument that instructs the method to
+silently drop points that can not be located on the topology. This setting was
+partially ignored by trimmed topologies which could lead to a `LocateError`
+despite the flag being set. This issue is now fixed.
+
+
 CHANGED: solve, solve_withinfo arguments
 
 Solver methods newton, minimize and pseudotime have their function signature

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -943,7 +943,8 @@ class locate(TestCase):
             self.domain.locate(self.geom, target, eps=1e-15, tol=1e-12, arguments=dict(scale=.123))
 
     def test_invalidpoint(self):
-        target = numpy.array([(.3, 1)])  # outside domain, but inside basetopo for mode==trimmed
+        target = numpy.array([(.3, 1), (.2, .3), (.1, .9), (0, 1), (.1, .3)])
+        # the first point is outside the domain, but inside basetopo for mode==trimmed
         with self.assertRaises(topology.LocateError):
             self.domain.locate(self.geom, target, eps=1e-15, tol=1e-12, arguments=dict(scale=.123))
 

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -945,8 +945,11 @@ class locate(TestCase):
     def test_invalidpoint(self):
         target = numpy.array([(.3, 1), (.2, .3), (.1, .9), (0, 1), (.1, .3)])
         # the first point is outside the domain, but inside basetopo for mode==trimmed
-        with self.assertRaises(topology.LocateError):
+        with self.subTest('skip_missing=False'), self.assertRaises(topology.LocateError):
             self.domain.locate(self.geom, target, eps=1e-15, tol=1e-12, arguments=dict(scale=.123))
+        with self.subTest('skip_missing=True'):
+            sample = self.domain.locate(self.geom, target, eps=1e-15, tol=1e-12, arguments=dict(scale=.123), skip_missing=True)
+            self.assertEqual(sample.npoints, 4)
 
     def test_boundary(self):
         target = numpy.array([(.2,), (.1,), (0,)])


### PR DESCRIPTION
This PR fixes the behaviour of `SubsetTopology.locate` when `skip_missing` is set. Formerly it would fail if points that were found on the base topology (where `skip_missing` was honoured) but not in the subset. With this patch the flag instead triggers a post-processing step that prunes the initial sample.