### PR TITLE
remove remaining apply_annotations and cleanup

### DIFF
--- a/nutils/element.py
+++ b/nutils/element.py
@@ -316,9 +316,6 @@ class Reference(types.Singleton):
         raise NotImplementedError
 
 
-strictreference = types.strict[Reference]
-
-
 class EmptyLike(Reference):
     'inverse reference element'
 

--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -75,9 +75,6 @@ def asarray(arg):
         return constant(arg)
 
 
-asarrays = types.tuple[asarray]
-
-
 def _isindex(arg):
     return isinstance(arg, Array) and arg.ndim == 0 and arg.dtype == int and arg._intbounds[0] >= 0
 
@@ -5078,13 +5075,15 @@ def loop_index(name, length):
 
 def loop_sum(func, index):
     func = asarray(func)
-    index = types.strict[_LoopIndex](index)
+    if not isinstance(index, _LoopIndex):
+        raise TypeError(f'expected _LoopIndex, got {index!r}')
     return LoopSum(func, func.shape, index._name, index.length)
 
 
 def _loop_concatenate_data(func, index):
     func = asarray(func)
-    index = types.strict[_LoopIndex](index)
+    if not isinstance(index, _LoopIndex):
+        raise TypeError(f'expected _LoopIndex, got {index!r}')
     chunk_size = func.shape[-1]
     if chunk_size.isconstant:
         chunk_sizes = InsertAxis(chunk_size, index.length)

--- a/nutils/mesh.py
+++ b/nutils/mesh.py
@@ -446,8 +446,7 @@ def parsegmsh(mshdata):
 
 
 @log.withcontext
-@types.apply_annotations
-def gmsh(fname: util.binaryfile, name='gmsh', *, space='X'):
+def gmsh(fname, name='gmsh', *, space='X'):
     """Gmsh parser
 
     Parser for Gmsh files in `.msh` format. Only files with physical groups are
@@ -469,7 +468,7 @@ def gmsh(fname: util.binaryfile, name='gmsh', *, space='X'):
         Isoparametric map.
     """
 
-    with fname as f:
+    with util.binaryfile(fname) as f:
         return simplex(name=name, **parsegmsh(f), space=space)
 
 

--- a/nutils/points.py
+++ b/nutils/points.py
@@ -112,9 +112,6 @@ class Points(types.Singleton):
         return types.frozenarray(onhull, copy=False)
 
 
-strictpoints = types.strict[Points]
-
-
 class CoordsPoints(Points):
     '''Manually supplied points.'''
 
@@ -266,7 +263,7 @@ class TransformPoints(Points):
 
     __cache__ = 'coords', 'weights'
 
-    def __init__(self, points: strictpoints, trans: transform.stricttransformitem):
+    def __init__(self, points: Points, trans: transform.TransformItem):
         assert isinstance(points, Points), f'points={points!r}'
         assert isinstance(trans, transform.TransformItem), f'trans={trans!r}'
         self.points = points

--- a/nutils/points.py
+++ b/nutils/points.py
@@ -340,33 +340,6 @@ class ConcatPoints(Points):
         return types.frozenarray(numpy.concatenate([renum.take(points.tri) for renum, points in zip(renumber, self.allpoints)]), copy=False)
 
 
-class ConePoints(Points):
-    '''Affinely transformed lower-dimensional points plus tip.
-
-    The point count is incremented by one regardless of the nature of the point
-    set; no effort is made to introduce extra points between base plane and tip.
-    Likewise, the simplex count stays equal, with all simplices obtaining an
-    extra vertex in tip.
-    '''
-
-    __cache__ = 'coords', 'tri'
-
-    @types.apply_annotations
-    def __init__(self, edgepoints: strictpoints, edgeref: transform.stricttransformitem, tip: types.arraydata):
-        self.edgepoints = edgepoints
-        self.edgeref = edgeref
-        self.tip = numpy.asarray(tip)
-        super().__init__(edgepoints.npoints+1, edgepoints.ndims+1)
-
-    @property
-    def coords(self):
-        return types.frozenarray(numpy.concatenate([self.edgeref.apply(self.edgepoints.coords), self.tip[_, :]]), copy=False)
-
-    @property
-    def tri(self):
-        tri = numpy.concatenate([self.edgepoints.tri, [[self.edgepoints.npoints]]*len(self.edgepoints.tri)], axis=1)
-        return types.frozenarray(tri, copy=False)
-
 # UTILITY FUNCTIONS
 
 

--- a/nutils/points.py
+++ b/nutils/points.py
@@ -7,6 +7,8 @@ and :class:`SimplexGaussPoints` that reflect the variety of elements in the
 '''
 
 from . import types, transform, numeric, _util as util
+from typing import Tuple, FrozenSet
+from numbers import Integral
 import numpy
 import functools
 import itertools
@@ -42,8 +44,9 @@ class Points(types.Singleton):
 
     __cache__ = 'tri', 'hull', 'onhull'
 
-    @types.apply_annotations
-    def __init__(self, npoints: types.strictint, ndims: types.strictint):
+    def __init__(self, npoints: Integral, ndims: Integral):
+        assert isinstance(npoints, Integral), f'npoints={npoints!r}'
+        assert isinstance(ndims, Integral), f'ndims={ndims!r}'
         self.npoints = npoints
         self.ndims = ndims
 
@@ -115,9 +118,8 @@ strictpoints = types.strict[Points]
 class CoordsPoints(Points):
     '''Manually supplied points.'''
 
-    @types.apply_annotations
     def __init__(self, coords: types.arraydata):
-        assert coords.dtype == float
+        assert isinstance(coords, types.arraydata) and coords.ndim == 2 and coords.dtype == float, f'coords={coords!r}'
         self.coords = numpy.asarray(coords)
         super().__init__(*coords.shape)
 
@@ -125,10 +127,9 @@ class CoordsPoints(Points):
 class CoordsWeightsPoints(CoordsPoints):
     '''Manually supplied points and weights.'''
 
-    @types.apply_annotations
     def __init__(self, coords: types.arraydata, weights: types.arraydata):
-        assert coords.dtype == float
-        assert weights.dtype == float
+        assert isinstance(coords, types.arraydata) and coords.ndim == 2 and coords.dtype == float, f'coords={coords!r}'
+        assert isinstance(weights, types.arraydata) and weights.ndim == 1 and weights.dtype == float, f'weights={weights!r}'
         self.weights = numpy.asarray(weights)
         super().__init__(coords)
 
@@ -136,8 +137,9 @@ class CoordsWeightsPoints(CoordsPoints):
 class CoordsUniformPoints(CoordsPoints):
     '''Manually supplied points with uniform weights.'''
 
-    @types.apply_annotations
     def __init__(self, coords: types.arraydata, volume: float):
+        assert isinstance(coords, types.arraydata) and coords.ndim == 2 and coords.dtype == float, f'coords={coords!r}'
+        assert isinstance(volume, float), f'volume={volume!r}'
         self.weights = numeric.full(coords.shape[:1], fill_value=volume/coords.shape[0], dtype=float)
         super().__init__(coords)
 
@@ -147,8 +149,9 @@ class TensorPoints(Points):
 
     __cache__ = 'coords', 'weights', 'tri', 'hull'
 
-    @types.apply_annotations
-    def __init__(self, points1: strictpoints, points2: strictpoints):
+    def __init__(self, points1: Points, points2: Points):
+        assert isinstance(points1, Points), f'points1={points1!r}'
+        assert isinstance(points2, Points), f'points2={points2!r}'
         self.points1 = points1
         self.points2 = points2
         super().__init__(points1.npoints * points2.npoints, points1.ndims + points2.ndims)
@@ -207,8 +210,9 @@ class TensorPoints(Points):
 class SimplexGaussPoints(CoordsWeightsPoints):
     '''Gauss quadrature points on a simplex.'''
 
-    @types.apply_annotations
-    def __init__(self, ndims: types.strictint, degree: types.strictint):
+    def __init__(self, ndims: Integral, degree: Integral):
+        assert isinstance(ndims, Integral), f'ndims={ndims!r}'
+        assert isinstance(degree, Integral), f'degree={degree!r}'
         super().__init__(*gaussn[ndims](degree))
 
 
@@ -217,11 +221,12 @@ class SimplexBezierPoints(CoordsUniformPoints):
 
     __cache__ = 'tri'
 
-    @types.apply_annotations
-    def __init__(self, ndims: types.strictint, n: types.strictint):
+    def __init__(self, ndims: Integral, n: Integral):
+        assert isinstance(ndims, Integral), f'ndims={ndims!r}'
+        assert isinstance(n, Integral), f'n={n!r}'
         self.n = n
         self._indices = numpy.array([index[::-1] for index in numpy.ndindex(*[n] * ndims) if sum(index) < n])
-        super().__init__(self._indices/(n-1), 1/math.factorial(ndims))
+        super().__init__(types.arraydata(self._indices/(n-1)), 1/math.factorial(ndims))
 
     @property
     def _indexgrid(self):
@@ -261,8 +266,9 @@ class TransformPoints(Points):
 
     __cache__ = 'coords', 'weights'
 
-    @types.apply_annotations
     def __init__(self, points: strictpoints, trans: transform.stricttransformitem):
+        assert isinstance(points, Points), f'points={points!r}'
+        assert isinstance(trans, transform.TransformItem), f'trans={trans!r}'
         self.points = points
         self.trans = trans
         super().__init__(points.npoints, points.ndims)
@@ -293,8 +299,9 @@ class ConcatPoints(Points):
 
     __cache__ = 'coords', 'weights', 'tri', 'masks'
 
-    @types.apply_annotations
-    def __init__(self, allpoints: types.tuple[strictpoints], duplicates: frozenset = frozenset()):
+    def __init__(self, allpoints: Tuple[Points,...], duplicates: FrozenSet[Tuple[Tuple[Integral,Integral],...]]):
+        assert isinstance(allpoints, tuple) and all(isinstance(p, Points) for p in allpoints), 'allpoints={allpoints!r}'
+        assert isinstance(duplicates, frozenset) and all(isinstance(d, tuple) and all(isinstance(n, tuple) and len(n) == 2 and all(isinstance(ni, Integral) for ni in n) for n in d) for d in duplicates), f'duplicates={duplicates!r}'
         self.allpoints = allpoints
         self.duplicates = duplicates
         super().__init__(sum(points.npoints for points in allpoints) - sum(len(d)-1 for d in duplicates), allpoints[0].ndims)
@@ -348,14 +355,14 @@ def gauss(n):
     k = numpy.arange(n) + 1
     d = k / numpy.sqrt(4*k**2-1)
     x, w = numpy.linalg.eigh(numpy.diagflat(d, -1))  # eigh operates (by default) on lower triangle
-    return types.frozenarray((x+1) * .5, copy=False), types.frozenarray(w[0]**2, copy=False)
+    return types.arraydata((x+1) * .5), types.arraydata(w[0]**2)
 
 
 def gauss1(degree):
     '''Gauss quadrature for line.'''
 
     x, w = gauss(degree//2)
-    return x[:, _], w
+    return x.reshape(*x.shape, 1), w
 
 
 @functools.lru_cache(8)
@@ -398,8 +405,8 @@ def gauss2(degree):
     if degree > 6:
         warnings.warn('inexact integration for polynomial of degree {}'.format(degree))
 
-    return types.frozenarray(numpy.concatenate([numpy.take(c, i) for i, c, w in icw]), copy=False), \
-        types.frozenarray(numpy.concatenate([[w/2] * len(i) for i, c, w in icw]), copy=False)
+    return types.arraydata(numpy.concatenate([numpy.take(c, i) for i, c, w in icw])), \
+        types.arraydata(numpy.concatenate([[w/2] * len(i) for i, c, w in icw]))
 
 
 @functools.lru_cache(8)
@@ -456,8 +463,8 @@ def gauss3(degree):
     if degree > 7:
         warnings.warn('inexact integration for polynomial of degree {}'.format(degree))
 
-    return types.frozenarray(numpy.concatenate([numpy.take(c, i) for i, c, w in icw]), copy=False), \
-        types.frozenarray(numpy.concatenate([[w/6] * len(i) for i, c, w in icw]), copy=False)
+    return types.arraydata(numpy.concatenate([numpy.take(c, i) for i, c, w in icw])), \
+        types.arraydata(numpy.concatenate([[w/6] * len(i) for i, c, w in icw]))
 
 
 gaussn = None, gauss1, gauss2, gauss3
@@ -468,6 +475,6 @@ def find_duplicates(allpoints):
     for i, points in enumerate(allpoints):
         for j in points.onhull.nonzero()[0]:
             coords.setdefault(tuple(points.coords[j]), []).append((i, j))
-    return [tuple(pairs) for pairs in coords.values() if len(pairs) > 1]
+    return frozenset(tuple(pairs) for pairs in coords.values() if len(pairs) > 1)
 
 # vim:sw=4:sts=4:et

--- a/nutils/pointsseq.py
+++ b/nutils/pointsseq.py
@@ -519,8 +519,9 @@ class _Product(PointsSequence):
 
     __slots__ = 'sequence1', 'sequence2'
 
-    @types.apply_annotations
-    def __init__(self, sequence1, sequence2):
+    def __init__(self, sequence1: PointsSequence, sequence2: PointsSequence):
+        assert isinstance(sequence1, PointsSequence), f'sequence1={sequence1!r}'
+        assert isinstance(sequence2, PointsSequence), f'sequence2={sequence2!r}'
         assert not (isinstance(sequence1, _Uniform) and isinstance(sequence2, _Uniform)), 'inefficient; this should have been `_Uniform`'
         self.sequence1 = sequence1
         self.sequence2 = sequence2

--- a/nutils/topology.py
+++ b/nutils/topology.py
@@ -1825,7 +1825,7 @@ class EmptyTopology(TransformChainsTopology):
         return other
 
 
-def StructuredLine(space, root: transform.stricttransformitem, i: int, j: int, periodic: bool = False, bnames: Optional[Tuple[str, str]] = None):
+def StructuredLine(space, root: transform.TransformItem, i: int, j: int, periodic: bool = False, bnames: Optional[Tuple[str, str]] = None):
     assert isinstance(i, int), f'i={i!r}'
     assert isinstance(j, int), f'j={j!r}'
     assert isinstance(periodic, bool), f'periodic={periodic!r}'

--- a/nutils/topology.py
+++ b/nutils/topology.py
@@ -1565,8 +1565,8 @@ class TransformChainsTopology(Topology):
             transforms += self.opposites[unique_ielems],
 
         slices = [index[n:m] for n, m in zip(offsets[:-1], offsets[1:])]
-        points_ = PointsSequence.from_iter([points.CoordsPoints(coords[s]) for s in slices] if weights is None
-                                           else [points.CoordsWeightsPoints(coords[s], weights[s]) for s in slices], self.ndims)
+        points_ = PointsSequence.from_iter([points.CoordsPoints(types.arraydata(coords[s])) for s in slices] if weights is None
+            else [points.CoordsWeightsPoints(types.arraydata(coords[s]), types.arraydata(weights[s])) for s in slices], self.ndims)
 
         return Sample.new(self.space, transforms, points_, index)
 

--- a/nutils/transform.py
+++ b/nutils/transform.py
@@ -108,10 +108,6 @@ class TransformItem(types.Singleton):
         return None
 
 
-stricttransformitem = types.strict[TransformItem]
-stricttransform = types.tuple[stricttransformitem]
-
-
 class Matrix(TransformItem):
     '''Affine transformation :math:`x ↦ A x + b`, with :math:`A` an :math:`n×m` matrix, :math:`n≥m`
 

--- a/nutils/transformseq.py
+++ b/nutils/transformseq.py
@@ -308,9 +308,6 @@ class Transforms(types.Singleton):
         yield self
 
 
-stricttransforms = types.strict[Transforms]
-
-
 class EmptyTransforms(Transforms):
     '''An empty sequence.'''
 

--- a/nutils/types.py
+++ b/nutils/types.py
@@ -16,12 +16,9 @@ import re
 import io
 import types
 import numpy
+import dataclasses
 from ctypes import byref, c_int, c_ssize_t, c_void_p, c_char_p, py_object, pythonapi, Structure, POINTER
 c_ssize_p = POINTER(c_ssize_t)
-try:
-    import dataclasses
-except ImportError:
-    dataclasses = None
 
 
 def aspreprocessor(apply):
@@ -316,7 +313,7 @@ def nutils_hash(data):
     elif t is numpy.ndarray and not data.flags.writeable:
         h.update('{}{}\0'.format(','.join(map(str, data.shape)), data.dtype.str).encode())
         h.update(data.tobytes())
-    elif dataclasses and dataclasses.is_dataclass(t):
+    elif dataclasses.is_dataclass(t):
         # Note: we cannot use dataclasses.asdict here as its built-in recursion
         # makes nested dataclass instances indistinguishable from dictionaries.
         for item in sorted(nutils_hash((field.name, getattr(data, field.name))) for field in dataclasses.fields(t)):

--- a/nutils/types.py
+++ b/nutils/types.py
@@ -752,6 +752,11 @@ class arraydata(Singleton):
         dtype = dict(b=bool, u=int, i=int, f=float, c=complex)[array.dtype.kind]
         return super().__new__(cls, dtype, array.shape, array.astype(dtype, copy=False).tobytes())
 
+    def reshape(self, *shape):
+        if numpy.prod(shape) != numpy.prod(self.shape):
+            raise ValueError(f'cannot reshape arraydata of shape {self.shape} into shape {shape}')
+        return super().__new__(self.__class__, self.dtype, shape, self.bytes)
+
     def __init__(self, dtype, shape, bytes):
         self.dtype = dtype
         self.shape = shape

--- a/nutils/types.py
+++ b/nutils/types.py
@@ -1209,40 +1209,6 @@ def frozenarray(arg, *, copy=True, dtype=None):
     return array
 
 
-class _c_arraymeta(type):
-    def __getitem__(self, dtype):
-        def constructor(value):
-            if isinstance(value, numpy.core._internal._ctypes):
-                return value
-            if not isinstance(value, numpy.ndarray):
-                value = numpy.array(value, dtype=dtype)
-            if not value.flags.c_contiguous:
-                raise ValueError('Array is not contiguous.')
-            if value.dtype != dtype:
-                raise ValueError('Expected dtype {} but array has dtype {}.'.format(dtype, value.dtype))
-            return value.ctypes
-        constructor.__qualname__ = constructor.__name__ = 'c_array[{}]'.format(_getname(dtype))
-        return constructor
-
-    def __call__(*args, **kwargs):
-        raise TypeError("cannot create an instance of class 'c_array'")
-
-
-class c_array(metaclass=_c_arraymeta):
-    '''
-    Converts an array-like object to a ctypes array with a specific dtype.  The
-    function ``c_array[dtype](array)`` returns ``array`` unmodified if ``array``
-    is already a ctypes array.  If ``array`` is a :class:`numpy.ndarray`, the
-    array is converted if the ``dtype`` is correct and the array is contiguous;
-    otherwise :class:`ValueError` is raised.  Otherwise, ``array`` is first
-    converted to a contiguous :class:`numpy.ndarray` and then converted to ctypes
-    array.  In the first two cases changes made to the ctypes array are reflected
-    by the ``array`` argument: both are essentially views of the same data.  In
-    the third case, changes to either ``array`` or the returned ctypes array are
-    not reflected by the other.
-    '''
-
-
 def lru_cache(func):
     '''Buffer-aware cache.
 

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -1,4 +1,4 @@
-from nutils import element, _util as util
+from nutils import element, _util as util, types
 from nutils.testing import TestCase, parametrize
 import numpy, math
 
@@ -103,6 +103,6 @@ elem('prism1', ref=element.TriangleReference()*element.LineReference(), exactcen
 elem('prism2', ref=element.LineReference()*element.TriangleReference(), exactcentroid=numpy.array([1/2, 1/3, 1/3]))
 line = element.LineReference()
 quad = line**2
-elem('withchildren1', ref=element.WithChildrenReference(quad, [quad, quad.empty, quad.empty, quad.empty]), exactcentroid=numpy.array([1/4, 1/4]))
-elem('withchildren2', ref=element.WithChildrenReference(quad, [quad, quad, quad.empty, quad.empty]), exactcentroid=numpy.array([1/4, 1/2]))
-elem('mosaic', ref=element.MosaicReference(quad, [line, line.empty, line, line.empty], [.25, .75]), exactcentroid=numpy.array([2/3, 2/3]))
+elem('withchildren1', ref=element.WithChildrenReference(quad, (quad, quad.empty, quad.empty, quad.empty)), exactcentroid=numpy.array([1/4, 1/4]))
+elem('withchildren2', ref=element.WithChildrenReference(quad, (quad, quad, quad.empty, quad.empty)), exactcentroid=numpy.array([1/4, 1/2]))
+elem('mosaic', ref=element.MosaicReference(quad, (line, line.empty, line, line.empty), types.arraydata([.25, .75])), exactcentroid=numpy.array([2/3, 2/3]))

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -332,116 +332,6 @@ class CacheMeta(TestCase):
                 self.assertEqual(ncalls, 1)
 
 
-class strictint(TestCase):
-
-    def test_int(self):
-        value = nutils.types.strictint(1)
-        self.assertEqual(value, 1)
-        self.assertEqual(type(value), int)
-
-    def test_numpy_int(self):
-        value = nutils.types.strictint(numpy.int64(1))
-        self.assertEqual(value, 1)
-        self.assertEqual(type(value), int)
-
-    def test_float(self):
-        with self.assertRaises(ValueError):
-            nutils.types.strictint(1.)
-
-    def test_numpy_float(self):
-        with self.assertRaises(ValueError):
-            nutils.types.strictint(numpy.float64(1.))
-
-    def test_complex(self):
-        with self.assertRaises(ValueError):
-            nutils.types.strictint(1+0j)
-
-    def test_str(self):
-        with self.assertRaises(ValueError):
-            nutils.types.strictint('1')
-
-
-class strictfloat(TestCase):
-
-    def test_int(self):
-        value = nutils.types.strictfloat(1)
-        self.assertEqual(value, 1.)
-        self.assertEqual(type(value), float)
-
-    def test_numpy_int(self):
-        value = nutils.types.strictfloat(numpy.int64(1))
-        self.assertEqual(value, 1.)
-        self.assertEqual(type(value), float)
-
-    def test_float(self):
-        value = nutils.types.strictfloat(1.)
-        self.assertEqual(value, 1.)
-        self.assertEqual(type(value), float)
-
-    def test_numpy_float(self):
-        value = nutils.types.strictfloat(numpy.float64(1.))
-        self.assertEqual(value, 1.)
-        self.assertEqual(type(value), float)
-
-    def test_complex(self):
-        with self.assertRaises(ValueError):
-            nutils.types.strictint(1+0j)
-
-    def test_str(self):
-        with self.assertRaises(ValueError):
-            nutils.types.strictfloat('1.')
-
-
-class strictstr(TestCase):
-
-    def test_str(self):
-        value = nutils.types.strictstr('spam')
-        self.assertEqual(value, 'spam')
-        self.assertEqual(type(value), str)
-
-    def test_int(self):
-        with self.assertRaises(ValueError):
-            nutils.types.strictstr(1)
-
-
-class strict(TestCase):
-
-    def test_valid(self):
-        self.assertEqual(nutils.types.strict[int](1), 1)
-
-    def test_invalid(self):
-        with self.assertRaises(ValueError):
-            nutils.types.strict[int]('1')
-
-    def test_call(self):
-        with self.assertRaises(TypeError):
-            nutils.types.strict()
-
-
-class tupletype(TestCase):
-
-    def test_valid1(self):
-        value = nutils.types.tuple[nutils.types.strictint]([])
-        self.assertEqual(value, ())
-        self.assertEqual(type(value), tuple)
-
-    def test_valid2(self):
-        value = nutils.types.tuple[nutils.types.strictint]([1, 2, 3])
-        self.assertEqual(value, (1, 2, 3))
-        self.assertEqual(type(value), tuple)
-
-    def test_invalid(self):
-        with self.assertRaises(ValueError):
-            nutils.types.tuple[nutils.types.strictint]([1, 'spam', 'eggs'])
-
-    def test_without_item_constructor(self):
-        src = 1, 2, 3
-        self.assertEqual(nutils.types.tuple(src), tuple(src))
-
-    def test_name(self):
-        self.assertEqual(nutils.types.tuple[nutils.types.strictint].__name__, 'tuple[nutils.types.strictint]')
-
-
 class frozendict(TestCase):
 
     def test_constructor(self):
@@ -455,24 +345,6 @@ class frozendict(TestCase):
     def test_constructor_invalid(self):
         with self.assertRaises(ValueError):
             nutils.types.frozendict(['spam', 'eggs', 1])
-
-    def test_clsgetitem(self):
-        T = nutils.types.frozendict[str, float]
-        src = {1: 2, 'spam': '2.3'}
-        for name, value in [('mapping', src), ('mapping_view', src.items()), ('iterable', (item for item in src.items()))]:
-            with self.subTest(name):
-                frozen = T(value)
-                self.assertIsInstance(frozen, nutils.types.frozendict)
-                self.assertEqual(dict(frozen), {'1': 2., 'spam': 2.3})
-
-    def test_clsgetitem_invalid_types(self):
-        with self.assertRaises(RuntimeError):
-            nutils.types.frozendict[str, float, bool]
-
-    def test_clsgetitem_invalid_value(self):
-        T = nutils.types.frozendict[str, float]
-        with self.assertRaises(ValueError):
-            T(1)
 
     def test_setitem(self):
         frozen = nutils.types.frozendict({'spam': 1, 'eggs': 2.3})
@@ -564,11 +436,6 @@ class frozenmultiset(TestCase):
                 frozen = nutils.types.frozenmultiset(value)
                 for item in 'spam', 'bacon', 'sausage':
                     self.assertEqual({k: tuple(frozen).count(k) for k in set(src)}, {'spam': 2, 'bacon': 1, 'sausage': 1})
-
-    def test_clsgetitem(self):
-        src = False, 1, numpy.int64(2)
-        frozen = nutils.types.frozenmultiset[nutils.types.strictint](src)
-        self.assertEqual(set(frozen), {0, 1, 2})
 
     def test_preserve_order(self):
         for src in [('spam', 'bacon', 'sausage', 'spam'), ('spam', 'egg', 'spam', 'spam', 'bacon', 'spam')]:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -822,39 +822,6 @@ class frozenarray(TestCase):
         self.assertFalse(a.flags.writeable)
 
 
-class c_array(TestCase):
-
-    def test_idempotence(self):
-        a = numpy.array([1, 2, 3], dtype=numpy.int64)
-        P = nutils.types.c_array[numpy.int64]
-        a_ct = P(a)
-        self.assertEqual(P(a_ct), a_ct)
-
-    def test_list(self):
-        a = [1, 2, 3]
-        a_ct = nutils.types.c_array[numpy.int64](a)
-        self.assertEqual(a_ct.data_as(ctypes.POINTER(ctypes.c_int64)).contents.value, 1)
-
-    def test_array(self):
-        a = numpy.array([1, 2, 3], dtype=numpy.int64)
-        a_ct = nutils.types.c_array[numpy.int64](a)
-        self.assertEqual(a_ct.data_as(ctypes.POINTER(ctypes.c_int64)).contents.value, 1)
-
-    def test_array_invalid_dtype(self):
-        a = numpy.array([1, 2, 3], dtype=numpy.int32)
-        with self.assertRaisesRegex(ValueError, '^Expected dtype .* but array has dtype .*\\.$'):
-            a_ct = nutils.types.c_array[numpy.int64](a)
-
-    def test_array_noncontinguous(self):
-        a = numpy.array([[1, 2], [3, 4]], dtype=numpy.int32).T
-        with self.assertRaisesRegex(ValueError, '^Array is not contiguous\\.$'):
-            a_ct = nutils.types.c_array[numpy.int64](a)
-
-    def test_wo_getitem(self):
-        with self.assertRaises(TypeError):
-            nutils.types.c_array()
-
-
 class T_Immutable(nutils.types.Immutable):
     def __init__(self, x, y, *, z):
         pass


### PR DESCRIPTION
This PR removes the last remaining occurrences of the `apply_annotations` decorator and proceeds to remove a lot of infrastructure that is no longer in use.