### PR TITLE
Variable arguments for Add and Multiply

### DIFF
--- a/tests/test_evaluable.py
+++ b/tests/test_evaluable.py
@@ -1277,7 +1277,7 @@ class log_error(TestCase):
   %1 = nutils.evaluable.Constant<f:> --> ndarray<f:>
   %2 = nutils.evaluable.Constant<f:2> --> ndarray<f:2>
   %3 = nutils.evaluable.Sum<f:> arr=%2 --> float64
-  %4 = nutils.evaluable.Add<f:> %1 %3 --> float64
+  %4 = nutils.evaluable.Add<f:> arg1=%1 arg2=%3 --> float64
   %5 = tests.test_evaluable.Fail<i:> arg1=%4 arg2=%1 --> operation failed intentially.''')
 
 

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -694,7 +694,10 @@ class piecewise(TestCase):
 
     def test_evalf(self):
         f_ = self.domain.sample('uniform', 4).eval(self.f)  # x=.125, .375, .625, .875
-        assert numpy.equal(f_, [1, numpy.sin(.375), numpy.sin(.625), .875**2]).all()
+        # small inaccuracies are possible due to sign-based implementation of
+        # partition, leading to order dependent rounding errors due to
+        # cancellation of terms
+        self.assertAllAlmostEqual(f_, [1, numpy.sin(.375), numpy.sin(.625), .875**2], places=15)
 
     def test_deriv(self):
         g_ = self.domain.sample('uniform', 4).eval(function.grad(self.f, self.geom))  # x=.125, .375, .625, .875


### PR DESCRIPTION
This PR changes the Multiply and Add operations to support any number of arguments for faster evaluation and more efficient simplifications.

For operations organized in a tree such as `(A + B) + (C + D)` it is difficult to discover relevant structures, for instance `A` and `D` having matching sparsity. In the current form, the only way to properly discover this is if `(A + B)._add(C + D)` dispatches to `A._add(C + D)` as well as the reverse `(C + D)._add(A)`, and from there to `D._add(A)`. While fuctional, it is impossible to avoid redundancy `(C + D)._add(A + B)` will explore most of the same combinations - a problem that grows rapidly with the depth of the tree. By moving to a flat structure `A + B + C + D` it is trivial to find patterns with minimal effort. Moreover, most simplifications currently defined on `Add` and `Multiply` are already valid for multiple arguments, so the new structure does not add complexity.