### PR TITLE
fix Multipatch.refined

### DIFF
--- a/nutils/topology.py
+++ b/nutils/topology.py
@@ -3249,6 +3249,6 @@ class MultipatchTopology(TransformChainsTopology):
     def refined(self):
         'refine'
 
-        return MultipatchTopology(Patch(patch.topo.refined, patch.verts, patch.boundaries) for patch in self.patches)
+        return MultipatchTopology(tuple(Patch(patch.topo.refined, patch.verts, patch.boundaries) for patch in self.patches))
 
 # vim:sw=4:sts=4:et

--- a/nutils/topology.py
+++ b/nutils/topology.py
@@ -3210,7 +3210,7 @@ class MultipatchTopology(TransformChainsTopology):
                 transforms = numeric.asobjvector(btopo.transforms).reshape(btopo.shape)
                 transforms = transforms[tuple(_ if i == boundary.dim else slice(None) for i in range(self.ndims))]
                 transforms = boundary.apply_transform(transforms)[..., 0]
-                pairs.append(tuple(transforms.flat))
+                pairs.append(tuple(map(transform.canonical, transforms.flat)))
             # create structured topology of joined element pairs
             references = References.from_iter(references, self.ndims-1)
             transforms, opposites = pairs

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -1057,6 +1057,8 @@ class multipatch_hyperrect(TestCase, TopologyAssertions):
             patchverts=tuple(itertools.product(*map(range, npatches+1))),
             nelems=4,
         )
+        if getattr(self, 'refined', False):
+            self.domain = self.domain.refined
 
     def test_spline_basis(self):
         basis = self.domain.basis('spline', degree=2)
@@ -1080,6 +1082,7 @@ class multipatch_hyperrect(TestCase, TopologyAssertions):
 
 multipatch_hyperrect('3', npatches=(3,))
 multipatch_hyperrect('2x2', npatches=(2, 2))
+multipatch_hyperrect('2x2-refined', npatches=(2, 2), refined=True)
 multipatch_hyperrect('3x3', npatches=(3, 3))
 multipatch_hyperrect('2x2x3', npatches=(2, 2, 3))
 


### PR DESCRIPTION
This PR fixes two issues with `Multipatch.refined`:

1.  In commit 7e29a2838 the `apply_annotations` decorators were removed from the `topology` module, including `Multipatch.__init__`, which wants a tuple of patches, but `Multipatch.refined`, which passed a generator of patches, was not changed accordingly.

2.  In commit 64d5f6f86 the `apply_annotations` decorators were removed from the `transformseq` module, including `PlainTransforms.__init__`, which wants a tuple of *canonical* transform chains, but `Multipatch.interfaces`, which passed a tuple of uncanonical transform chains when refined, was not changed accordingly.

In addition, this PR adds a test for refined multipatch topologies.