### PR TITLE
Nutils hash

### DIFF
--- a/nutils/types.py
+++ b/nutils/types.py
@@ -97,13 +97,11 @@ def nutils_hash(data):
 
     t = type(data)
     h = hashlib.sha1(t.__name__.encode()+b'\0')
-    if data is Ellipsis:
+    if data is Ellipsis or data is None:
         pass
-    elif data is None:
-        pass
-    elif any(data is dtype for dtype in (bool, int, float, complex, str, bytes, tuple, frozenset, type(Ellipsis), type(None))):
+    elif t is type:
         h.update(hashlib.sha1(data.__name__.encode()).digest())
-    elif any(t is dtype for dtype in (bool, int, float, complex)):
+    elif t in (bool, int, float, complex):
         h.update(hashlib.sha1(repr(data).encode()).digest())
     elif t is str:
         h.update(hashlib.sha1(data.encode()).digest())

--- a/nutils/types.py
+++ b/nutils/types.py
@@ -113,10 +113,13 @@ def nutils_hash(data):
         h.update(hashlib.sha1(data.encode()).digest())
     elif t is bytes:
         h.update(hashlib.sha1(data).digest())
-    elif t is tuple:
+    elif t in (list, tuple):
         for item in data:
             h.update(nutils_hash(item))
-    elif t is frozenset:
+    elif t is dict:
+        for item in sorted(nutils_hash(k) + nutils_hash(v) for k, v in data.items()):
+            h.update(item)
+    elif t in (set, frozenset):
         for item in sorted(map(nutils_hash, data)):
             h.update(item)
     elif issubclass(t, io.BufferedIOBase) and data.seekable():

--- a/nutils/types.py
+++ b/nutils/types.py
@@ -95,6 +95,12 @@ def nutils_hash(data):
     except AttributeError:
         pass
 
+    if isinstance(data, numpy.generic):
+        # normalize Numpy's scalar types so that their nutils_hash are equal to
+        # that of Python's counterparts, similar to Python's builtin hash
+        t = dict(b=bool, i=int, f=float, c=complex)[data.dtype.kind]
+        data = t(data)
+
     t = type(data)
     h = hashlib.sha1(t.__name__.encode()+b'\0')
     if data is Ellipsis or data is None:

--- a/nutils/types.py
+++ b/nutils/types.py
@@ -5,7 +5,6 @@ Module with general purpose types.
 import inspect
 import functools
 import hashlib
-import builtins
 import numbers
 import collections.abc
 import itertools
@@ -102,7 +101,7 @@ def nutils_hash(data):
         pass
     elif data is None:
         pass
-    elif any(data is dtype for dtype in (bool, int, float, complex, str, bytes, builtins.tuple, frozenset, type(Ellipsis), type(None))):
+    elif any(data is dtype for dtype in (bool, int, float, complex, str, bytes, tuple, frozenset, type(Ellipsis), type(None))):
         h.update(hashlib.sha1(data.__name__.encode()).digest())
     elif any(t is dtype for dtype in (bool, int, float, complex)):
         h.update(hashlib.sha1(repr(data).encode()).digest())
@@ -110,7 +109,7 @@ def nutils_hash(data):
         h.update(hashlib.sha1(data.encode()).digest())
     elif t is bytes:
         h.update(hashlib.sha1(data).digest())
-    elif t is builtins.tuple:
+    elif t is tuple:
         for item in data:
             h.update(nutils_hash(item))
     elif t is frozenset:
@@ -628,7 +627,7 @@ def _array_bases(obj):
 def _isimmutable(obj):
     return obj is None \
         or isinstance(obj, (Immutable, bool, int, float, complex, str, bytes, frozenset, numpy.generic)) \
-        or isinstance(obj, builtins.tuple) and all(_isimmutable(item) for item in obj) \
+        or isinstance(obj, tuple) and all(_isimmutable(item) for item in obj) \
         or isinstance(obj, frozendict) and all(_isimmutable(value) for value in obj.values()) \
         or isinstance(obj, numpy.ndarray) and not any(base.flags.writeable for base in _array_bases(obj))
 

--- a/nutils/types.py
+++ b/nutils/types.py
@@ -119,7 +119,7 @@ def nutils_hash(data):
     elif t is frozenset:
         for item in sorted(map(nutils_hash, data)):
             h.update(item)
-    elif issubclass(t, io.BufferedIOBase) and data.seekable() and not data.writable():
+    elif issubclass(t, io.BufferedIOBase) and data.seekable():
         pos = data.tell()
         h.update(str(pos).encode())
         data.seek(0)
@@ -131,7 +131,7 @@ def nutils_hash(data):
     elif t is types.MethodType:
         h.update(nutils_hash(data.__self__))
         h.update(nutils_hash(data.__name__))
-    elif t is numpy.ndarray and not data.flags.writeable:
+    elif t is numpy.ndarray:
         h.update('{}{}\0'.format(','.join(map(str, data.shape)), data.dtype.str).encode())
         h.update(data.tobytes())
     elif dataclasses.is_dataclass(t):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -75,9 +75,6 @@ class nutils_hash(TestCase):
 
     def test_ndarray(self):
         a = numpy.array([1, 2, 3])
-        with self.assertRaises(TypeError):
-            nutils.types.nutils_hash(a)
-        a.flags.writeable = False
         self.assertEqual(nutils.types.nutils_hash(a).hex(),
                          '299c2c796b4a71b7a2b310ddb29bba0440d77e26' if numpy.int_ == numpy.int64
                          else '9fee185ee111495718c129b4d3a8ae79975f3459')
@@ -121,8 +118,6 @@ class nutils_hash(TestCase):
                 f.seek(2)
                 self.assertEqual(nutils.types.nutils_hash(f).hex(), '490e9467ce36ddf487999a7b43d554737385e42f')
                 self.assertEqual(f.tell(), 2)
-            with open(path, 'rb+') as f, self.assertRaises(TypeError):
-                nutils.types.nutils_hash(f).hex()
         finally:
             os.unlink(path)
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -69,9 +69,24 @@ class nutils_hash(TestCase):
         self.assertEqual(nutils.types.nutils_hash((1,)).hex(), '328b16ebbc1815cf579ae038a35c4d68ebb022af')
         self.assertNotEqual(nutils.types.nutils_hash((1, 'spam')).hex(), nutils.types.nutils_hash(('spam', 1)).hex())
 
+    def test_list(self):
+        self.assertEqual(nutils.types.nutils_hash([]).hex(), '97cf24e05bb79e46a091f869c37f33bca00fb3de')
+        self.assertEqual(nutils.types.nutils_hash([1]).hex(), '6dbffad355664123aea1859cf3266d3c00f97c04')
+        self.assertNotEqual(nutils.types.nutils_hash([1, 'spam']).hex(), nutils.types.nutils_hash(['spam', 1]).hex())
+
     def test_frozenset(self):
         self.assertEqual(nutils.types.nutils_hash(frozenset([1, 2])).hex(), '3862dc7e5321bc8a576c385ed2c12c71b96a375a')
         self.assertEqual(nutils.types.nutils_hash(frozenset(['spam', 'eggs'])).hex(), '2c75fd3db57f5e505e1425ae9ff6dcbbc77fd123')
+
+    def test_set(self):
+        self.assertEqual(nutils.types.nutils_hash({1, 2}).hex(), '7c9837cc4583aa872d5d4184759b61db237d54f4')
+        self.assertEqual(nutils.types.nutils_hash({'spam', 'eggs'}).hex(), 'd7520a52096168b0909c14d87cc428d58bc0a0a2')
+
+    def test_frozendict(self):
+        self.assertEqual(nutils.types.nutils_hash(nutils.types.frozendict({1: 2, 'foo': 'bar'})).hex(), '2faf141728d232cc795f43adbb58f8f86eb9b71d')
+
+    def test_dict(self):
+        self.assertEqual(nutils.types.nutils_hash({1: 2, 'foo': 'bar'}).hex(), '6c17894a11374016735f846ed3ae8ef2b921b4b5')
 
     def test_ndarray(self):
         a = numpy.array([1, 2, 3])
@@ -128,8 +143,10 @@ class nutils_hash(TestCase):
         self.assertEqual(nutils.types.nutils_hash(self.custom()).hex(), b'01234567890123456789'.hex())
 
     def test_unhashable(self):
+        class MyUnhashableClass:
+            pass
         with self.assertRaises(TypeError):
-            nutils.types.nutils_hash([])
+            nutils.types.nutils_hash(MyUnhashableClass())
 
 
 class frozendict(TestCase):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -37,6 +37,12 @@ class nutils_hash(TestCase):
         self.assertEqual(nutils.types.nutils_hash(1).hex(), '00ec7dea895ebd921e56bbc554688d8b3a1e4dfc')
         self.assertEqual(nutils.types.nutils_hash(2).hex(), '8ae88fa39407cf75e46f9e0aba8c971de2256b14')
 
+    def test_numpy(self):
+        for t in bool, int, float, complex:
+            with self.subTest(t.__name__):
+                for d in numpy.arange(2, dtype=t):
+                    self.assertEqual(nutils.types.nutils_hash(d).hex(), nutils.types.nutils_hash(t(d)).hex())
+
     def test_float(self):
         self.assertEqual(nutils.types.nutils_hash(1.).hex(), 'def4bae4f2a3e29f6ddac537d3fa7c72195e5d8b')
         self.assertEqual(nutils.types.nutils_hash(2.5).hex(), '5216c2bf3c16d8b8ff4d9b79f482e5cea0a4cb95')


### PR DESCRIPTION
This PR extends `nutils_hash` support to type objects, Numpy generics, and mutable data including `list`, `set` and `dict`.