### PR TITLE
fix evaluable array const checks

### DIFF
--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -305,7 +305,7 @@ class Evaluable(types.Singleton):
 
     @property
     def isconstant(self):
-        return EVALARGS not in self.dependencies
+        return EVALARGS not in self.dependencies and not self.arguments
 
     @cached_property
     def ordereddeps(self):

--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -987,7 +987,7 @@ class Array(Evaluable, metaclass=_ArrayMeta):
     _inflations = ()
 
     def _derivative(self, var, seen):
-        if self.dtype in (bool, int) or var not in self.dependencies:
+        if self.dtype in (bool, int) or var not in self.arguments:
             return Zeros(self.shape + var.shape, dtype=self.dtype)
         raise NotImplementedError('derivative not defined for {}'.format(self.__class__.__name__))
 

--- a/tests/test_evaluable.py
+++ b/tests/test_evaluable.py
@@ -855,6 +855,26 @@ class derivative(TestCase):
         func = evaluable.IntToFloat(evaluable.BoolToInt(evaluable.Greater(arg, evaluable.zeros(()))))
         self.assertTrue(evaluable.iszero(evaluable.derivative(func, arg)))
 
+    def test_with_derivative(self):
+        arg = evaluable.Argument('arg', (evaluable.constant(3),), float)
+        deriv = numpy.arange(6, dtype=float).reshape(2, 3)
+        func = evaluable.zeros((evaluable.constant(2),), float)
+        func = evaluable.WithDerivative(func, arg, evaluable.asarray(deriv))
+        self.assertAllAlmostEqual(evaluable.derivative(func, arg).eval(), deriv)
+
+    def test_default_derivative(self):
+        # Tests whether `evaluable.Array._derivative` correctly raises an
+        # exception when taking a derivative to one of the arguments present in
+        # its `.arguments`.
+        class DefaultDeriv(evaluable.Array): pass
+        has_arg = evaluable.Argument('has_arg', (), float)
+        has_not_arg = evaluable.Argument('has_not_arg', (), float)
+        func = evaluable.WithDerivative(evaluable.Zeros((), float), has_arg, evaluable.Zeros((), float))
+        func = DefaultDeriv((func,), (), float)
+        with self.assertRaises(NotImplementedError):
+            evaluable.derivative(func, has_arg)
+        self.assertTrue(evaluable.iszero(evaluable.derivative(func, has_not_arg)))
+
 
 class asciitree(TestCase):
 


### PR DESCRIPTION
The `WithDerivative` evaluable defines a derivative of a wrapped array to some target. The target is not included in the `Evaluable.dependencies`, but is included in the `Array.arguments`. This PR fixes `Evaluable.isconstant` and `Array._derivative` (default impl) which both neglect to inspect the `.arguments`.