### PR TITLE
extend refined_by argument to include topologies

### DIFF
--- a/nutils/topology.py
+++ b/nutils/topology.py
@@ -2708,7 +2708,10 @@ class HierarchicalTopology(TransformChainsTopology):
         return self._rebase(self.basetopo.get_groups(*groups))
 
     def refined_by(self, refine):
-        refine = tuple(refine)
+        if isinstance(refine, Topology):
+            refine = refine.transforms
+        else:
+            refine = tuple(refine)
         if not all(map(numeric.isint, refine)):
             refine = tuple(self.transforms.index_with_tail(item)[0] for item in refine)
         refine = numpy.unique(numpy.array(refine, dtype=int))

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -973,7 +973,8 @@ class hierarchical(TestCase, TopologyAssertions):
         # Refine `self.domain` near `self.pos`.
         distance = ((self.geom-self.pos)**2).sum(0)**0.5
         for threshold in 0.3, 0.15:
-            self.domain = self.domain.refined_by(numpy.where(self.domain.elem_mean([distance], ischeme='gauss1', geometry=self.geom)[0] <= threshold)[0])
+            selection = self.domain.select(distance < threshold, ischeme='gauss1')
+            self.domain = self.domain.refined_by(selection)
 
     @parametrize.enable_if(lambda periodic, **params: not periodic)
     def test_boundaries(self):


### PR DESCRIPTION
Limited backport of #808. This patch adds support for Topology objects as refinement specifiers. In particular, this makes it possible to use the select method to make an element selection without having to take the transforms attribute of the result.