### PR TITLE
Preserve docstring formatting in cli

### DIFF
--- a/examples/cahnhilliard.py
+++ b/examples/cahnhilliard.py
@@ -62,7 +62,7 @@ def main(size: Length = parse('10cm'),
     energy:
 
         E(φ) := ∫_Ω ψ(φ) σ / ε + ∫_Ω .5 σ ε ‖∇φ‖² + ∫_Γ (σm + φ σd)
-                \                \                  \
+                \                \                  \ 
                  mixing energy    interface energy   wall energy
 
     Proof: the time derivative of `E` followed by substitution of the strong form

--- a/nutils/_util.py
+++ b/nutils/_util.py
@@ -721,7 +721,7 @@ def cli(f, *, argv=None):
         help = [usage]
         if doc.text:
             help.append('')
-            help.extend(textwrap.wrap(doc.text))
+            help.append(inspect.cleandoc(doc.text))
         if doc.argdocs:
             help.append('')
             for k, d in doc.argdocs.items():


### PR DESCRIPTION
This PR removes reflowing of the docstring text as it is shown by cli if it is invoked with the -h flag, instead removing only the common indentation.