### PR TITLE
log nutils version in cli.run, choose

### DIFF
--- a/nutils/_util.py
+++ b/nutils/_util.py
@@ -427,6 +427,18 @@ def in_context(context):
     return in_context_wrapper
 
 
+def log_version(f):
+
+    from . import version, version_name
+
+    @functools.wraps(f)
+    def log_version(*args, **kwargs):
+        treelog.info(f'NUTILS {version} "{version_name.title()}"')
+        return f(*args, **kwargs)
+
+    return log_version
+
+
 def log_arguments(f):
     '''Decorator to log a function's arguments.
 

--- a/nutils/cli.py
+++ b/nutils/cli.py
@@ -23,6 +23,7 @@ def run(f, *, argv=None):
         util.in_context(util.log_traceback),
         util.in_context(util.post_mortem),
         warnings.via(treelog.warning),
+        util.log_version,
         util.log_arguments,
         util.timeit(),
     )


### PR DESCRIPTION
This PR adds the `_util.log_version` context that logs the nutils version and release name, and adds it to the context list of `cli.run` so that the version is shown prior to any other output.