### PR TITLE
Add evaluable.eval, remove Array.session

### DIFF
--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -5161,6 +5161,28 @@ def einsum(fmt, *args, **dims):
 
 
 @util.single_or_multiple
+def eval(funcs: AsEvaluableArray, **arguments: typing.Mapping[str, numpy.ndarray]) -> typing.Tuple[numpy.ndarray, ...]:
+    '''Evaluate one or several Array objects.
+
+    Args
+    ----
+    funcs : :class:`tuple` of Array objects
+        Arrays to be evaluated.
+    arguments : :class:`dict` (default: None)
+        Optional arguments for function evaluation.
+
+    Returns
+    -------
+    results : :class:`tuple` of arrays
+    '''
+
+    funcs = Tuple(tuple(funcs)).simplified.optimized_for_numpy
+
+    with funcs.session(graphviz=graphviz) as eval:
+        return eval(**arguments)
+
+
+@util.single_or_multiple
 def eval_sparse(funcs: AsEvaluableArray, **arguments: typing.Mapping[str, numpy.ndarray]) -> typing.Tuple[numpy.ndarray, ...]:
     '''Evaluate one or several Array objects as sparse data.
 
@@ -5176,23 +5198,35 @@ def eval_sparse(funcs: AsEvaluableArray, **arguments: typing.Mapping[str, numpy.
     results : :class:`tuple` of sparse data arrays
     '''
 
-    funcs = [func.as_evaluable_array for func in funcs]
-    shape_chunks = Tuple(tuple(Tuple(builtins.sum(func.simplified._assparse, func.shape)) for func in funcs))
-    with shape_chunks.optimized_for_numpy.session(graphviz=graphviz) as eval:
-        for func, args in zip(funcs, eval(**arguments)):
-            shape = tuple(map(int, args[:func.ndim]))
-            chunks = [args[i:i+func.ndim+1] for i in range(func.ndim, len(args), func.ndim+1)]
-            length = builtins.sum(values.size for *indices, values in chunks)
-            data = numpy.empty((length,), dtype=sparse.dtype(shape, func.dtype))
-            start = 0
-            for *indices, values in chunks:
-                stop = start + values.size
-                d = data[start:stop].reshape(values.shape)
-                d['value'] = values
-                for idim, ii in enumerate(indices):
-                    d['index']['i'+str(idim)] = ii
-                start = stop
-            yield data
+    dense_funcs = []
+    dtype_slices = []
+
+    for func in funcs:
+        func = func.as_evaluable_array
+        ds = [func.dtype]
+        for v in [func.shape, *func.simplified._assparse]:
+            i = len(dense_funcs)
+            dense_funcs.extend(v)
+            j = len(dense_funcs)
+            ds.append(slice(i,j))
+        dtype_slices.append(ds)
+
+    dense_values = eval(dense_funcs, **arguments)
+
+    for dtype, *slices in dtype_slices:
+        shape, *chunks = [dense_values[s] for s in slices]
+        length = builtins.sum(values.size for *indices, values in chunks)
+        data = numpy.empty(length, dtype=sparse.dtype(shape, dtype))
+        start = 0
+        for *indices, values in chunks:
+            stop = start + values.size
+            d = data[start:stop].reshape(values.shape)
+            d['value'] = values
+            for idim, ii in enumerate(indices):
+                d['index'][f'i{idim}'] = ii
+            start = stop
+        assert start == length
+        yield data
 
 
 if __name__ == '__main__':

--- a/nutils/function.py
+++ b/nutils/function.py
@@ -2421,7 +2421,7 @@ class Basis(Array):
         super().__init__((ndofs,), float, spaces=index.spaces | coords.spaces, arguments=arguments)
 
         _index = evaluable.Argument('_index', shape=(), dtype=int)
-        self._arg_dofs, self._arg_coeffs = [f.optimized_for_numpy for f in self.f_dofs_coeffs(_index)]
+        self._arg_dofs, self._arg_coeffs = self.f_dofs_coeffs(_index)
         assert self._arg_dofs.ndim == 1
         assert self._arg_coeffs.ndim == 2
         assert evaluable._equals_simplified(self._arg_dofs.shape[0], self._arg_coeffs.shape[0])
@@ -2483,7 +2483,7 @@ class Basis(Array):
             A 1D Array of indices.
         '''
 
-        return self._arg_dofs.eval(_index=ielem)
+        return evaluable.eval(self._arg_dofs, _index=ielem)
 
     def get_ndofs(self, ielem: int) -> int:
         '''Return the number of basis functions with support on element ``ielem``.'''
@@ -2506,7 +2506,7 @@ class Basis(Array):
             :meth:`get_dofs`.
         '''
 
-        return self._arg_coeffs.eval(_index=numeric.normdim(self.nelems, ielem))
+        return evaluable.eval(self._arg_coeffs, _index=numeric.normdim(self.nelems, ielem))
 
     def f_dofs_coeffs(self, index: evaluable.Array) -> Tuple[evaluable.Array, evaluable.Array]:
         raise NotImplementedError('{} must implement f_dofs_coeffs'.format(self.__class__.__name__))

--- a/nutils/topology.py
+++ b/nutils/topology.py
@@ -1465,16 +1465,16 @@ class TransformChainsTopology(Topology):
         if leveltopo is None:
             ielem_arg = evaluable.Argument('_trim_index', (), dtype=int)
             coordinates = self.references.getpoints('vertex', maxrefine).get_evaluable_coords(ielem_arg)
-            levelset = levelset.lower(function.LowerArgs.for_space(self.space, (self.transforms, self.opposites), ielem_arg, coordinates)).optimized_for_numpy
+            levelset = levelset.lower(function.LowerArgs.for_space(self.space, (self.transforms, self.opposites), ielem_arg, coordinates))
             with log.iter.percentage('trimming', range(len(self)), self.references) as items:
                 for ielem, ref in items:
-                    levels = levelset.eval(_trim_index=ielem, **arguments)
+                    levels = evaluable.eval(levelset, _trim_index=ielem, **arguments)
                     refs.append(ref.trim(levels, maxrefine=maxrefine, ndivisions=ndivisions))
         else:
             log.info('collecting leveltopo elements')
             coordinates = evaluable.Points(evaluable.NPoints(), evaluable.constant(self.ndims))
             ielem = evaluable.Argument('_leveltopo_ielem', (), int)
-            levelset = levelset.lower(function.LowerArgs.for_space(self.space, (leveltopo.transforms, leveltopo.opposites), ielem, coordinates)).optimized_for_numpy
+            levelset = levelset.lower(function.LowerArgs.for_space(self.space, (leveltopo.transforms, leveltopo.opposites), ielem, coordinates))
             bins = [set() for ielem in range(len(self))]
             for trans in leveltopo.transforms:
                 ielem, tail = self.transforms.index_with_tail(trans)
@@ -1490,7 +1490,7 @@ class TransformChainsTopology(Topology):
                         imax = numpy.argmax([mask[indices].sum() for tail, points, indices in cover])
                         tail, points, indices = cover.pop(imax)
                         ielem = leveltopo.transforms.index(trans + tail)
-                        levels[indices] = levelset.eval(_leveltopo_ielem=ielem, _points=points, **arguments)
+                        levels[indices] = evaluable.eval(levelset, _leveltopo_ielem=ielem, _points=points, **arguments)
                         mask[indices] = False
                     refs.append(ref.trim(levels, maxrefine=maxrefine, ndivisions=ndivisions))
             log.debug('cache', fcache.stats)


### PR DESCRIPTION
This PR adds the `evaluable.eval` function for dense evaluation. This serves mainly to centralize some of the preprocessing logic required for evaluation, most notably `optimized_for_numpy`. The `evaluable.eval_sparse` function is rewritten to make use of `eval` internally.  The `Array.session` context is removed and integrated in `evalable.eval`.