### PR TITLE
fix picklability of sliced function array

### DIFF
--- a/nutils/function.py
+++ b/nutils/function.py
@@ -1589,12 +1589,6 @@ def get(__array: IntoArray, __axis: int, __index: IntoArray) -> Array:
     return numpy.take(Array.cast(__array), Array.cast(__index, dtype=int, ndim=0), __axis)
 
 
-def _range(__length: int, __offset: int) -> Array:
-    length = Array.cast(__length, dtype=int, ndim=0)
-    offset = Array.cast(__offset, dtype=int, ndim=0)
-    return _Wrapper(lambda l, o: evaluable.Range(l) + o, _WithoutPoints(length), _WithoutPoints(offset), shape=(__length,), dtype=int)
-
-
 def _takeslice(__array: IntoArray, __s: slice, __axis: int) -> Array:
     array = Array.cast(__array)
     s = __s
@@ -1605,7 +1599,8 @@ def _takeslice(__array: IntoArray, __s: slice, __axis: int) -> Array:
         stop = n if s.stop is None else s.stop if s.stop >= 0 else s.stop + n
         if start == 0 and stop == n:
             return array
-        index = _range(stop-start, start)
+        length = stop - start
+        index = _Wrapper(evaluable.Range, _WithoutPoints(_Constant(length)), shape=(length,), dtype=int) + start
     elif isinstance(n, numbers.Integral):
         index = Array.cast(numpy.arange(*s.indices(int(n))))
     else:

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -6,6 +6,7 @@ import itertools
 import warnings as _builtin_warnings
 import functools
 import fractions
+import pickle
 
 
 class Array(TestCase):
@@ -166,6 +167,12 @@ class check(TestCase):
         actual = self.op(*self.args).as_evaluable_array.eval()
         desired = self.n_op(*self.args)
         self.assertArrayAlmostEqual(actual, desired, decimal=15)
+
+    def test_pickle(self):
+        f = self.op(*self.args)
+        s = pickle.dumps(f)
+        f_ = pickle.loads(s)
+        self.assertEqual(f.as_evaluable_array, f_.as_evaluable_array)
 
 
 def generate(*shape, real, imag, zero, negative):


### PR DESCRIPTION
This PR changed the implementation of `_takeslice` such that it wraps `evaluable.Range` directly rather than a lambda function, which caused the resulting array to not be picklable. A unit test is added to safeguard against similar mistakes in future.