### PR TITLE
linear constraints

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -94,7 +94,7 @@ jobs:
           # Install Nutils from `dist` dir created in job `build-python-package`.
           python -um pip install "$_wheel[import_gmsh,export_mpl]"
       - name: Install Scipy
-        if: ${{ matrix.matrix-backend == 'scipy' }}
+        # FIXME: temporarily install scipy unconditionally
         run: python -um pip install --upgrade scipy
       - name: Configure MKL
         if: ${{ matrix.matrix-backend == 'mkl' }}

--- a/examples/platewithhole.py
+++ b/examples/platewithhole.py
@@ -120,7 +120,7 @@ def main(mode: Union[FCM, NURBS] = NURBS(),
     ns.define_for('x', gradient='∇', normal='n', jacobians=('dV', 'dS'))
     ns.λ = 2 * poisson
     ns.μ = 1 - poisson
-    ns.add_field(('u', 'v'), basis, shape=(2,))
+    ns.add_field(('u', 'v', 'w'), basis, shape=(2,))
     ns.X_i = 'x_i + u_i'
     ns.ε_ij = '(∇_j(u_i) + ∇_i(u_j)) / 2'
     ns.σ_ij = 'λ ε_kk δ_ij + 2 μ ε_ij'
@@ -135,14 +135,11 @@ def main(mode: Union[FCM, NURBS] = NURBS(),
     radiuserr = topo.boundary['hole'].integrate('dr^2 dS' @ ns, degree=9)**.5
     log.info('hole radius exact up to L2 error {:.2e}'.format(radiuserr))
 
-    sqr = topo.boundary['sym'].integral('(u_i n_i)^2 dS' @ ns, degree=degree*2)
-    cons = solver.optimize(('u',), sqr, droptol=1e-15)
+    res = topo.boundary['sym'].integral('w_j n_j u_i n_i dS' @ ns, degree=degree*2)
+    res += topo.boundary['far'].integral('w_k du_k dS' @ ns, degree=20)
 
-    sqr = topo.boundary['far'].integral('du_k du_k dS' @ ns, degree=20)
-    cons = solver.optimize(('u',), sqr, droptol=1e-15, constrain=cons)
-
-    res = topo.integral('∇_j(v_i) σ_ij dV' @ ns, degree=degree*2)
-    args = solver.solve_linear('u:v', res, constrain=cons)
+    res += topo.integral('∇_j(v_i) σ_ij dV' @ ns, degree=degree*2)
+    args = solver.solve_linear('u:v:w', res)
 
     bezier = topo.sample('bezier', 5)
     X, σxx = bezier.eval(['X_i', 'σ_00'] @ ns, **args)
@@ -151,21 +148,17 @@ def main(mode: Union[FCM, NURBS] = NURBS(),
     err = numpy.sqrt(topo.integrate(['du_k du_k dV', '∇_j(du_i) ∇_j(du_i) dV'] @ ns, degree=max(degree, 3)*2, arguments=args))
     log.user('errors: L2={:.2e}, H1={:.2e}'.format(*err))
 
-    return err, cons, args
+    return err, args
 
 
 class test(testing.TestCase):
 
     def test_spline(self):
-        err, cons, args = main(mode=FCM(nelems=4, btype='spline'))
+        err, args = main(mode=FCM(nelems=4, btype='spline'))
         with self.subTest('l2-error'):
             self.assertAlmostEqual(err[0], .00033, places=5)
         with self.subTest('h1-error'):
             self.assertAlmostEqual(err[1], .00674, places=5)
-        with self.subTest('constraints'):
-            self.assertAlmostEqual64(cons['u'], '''
-                eNpjaGBoYGBAxvrnGBow4X89g3NQFSjQwLAGq7i10Wus4k+NfM8fNWZgOGL89upc47WX0ozvXjAzPn1e
-                1TjnPACrACoJ''')
         with self.subTest('left-hand side'):
             self.assertAlmostEqual64(args['u'], '''
                 eNpbb3bMjIHhxzkGBhMgtgdi/XMqp8RPvjLxOPPCcNq5Fn3Pcxr6luf+6xmcm2LMwLDQePf5c0bTzx8x
@@ -173,15 +166,11 @@ class test(testing.TestCase):
                 KFD8iPHbq3ON115KM757wcz49HlV45zzAL8gQC8=''')
 
     def test_mixed(self):
-        err, cons, args = main(mode=FCM(nelems=4, etype='mixed'))
+        err, args = main(mode=FCM(nelems=4, etype='mixed'))
         with self.subTest('l2-error'):
             self.assertAlmostEqual(err[0], .00024, places=5)
         with self.subTest('h1-error'):
             self.assertAlmostEqual(err[1], .00740, places=5)
-        with self.subTest('constraints'):
-            self.assertAlmostEqual64(cons['u'], '''
-                eNpjaGDADhlwiOEU1z8HZusbgukkg5BzRJqKFRoa1oD1HzfceA5NH9FmgKC10SuwOdONpM7DxDYa77gM
-                MueoMQPDEePzV2Hic42XXmoynnQRxvc3dryQbnz3Aoj91Mj3vJnx6fOqxjnnAQzkV94=''')
         with self.subTest('left-hand side'):
             self.assertAlmostEqual64(args['u'], '''
                 eNoNzEEoQ3EcB/AXVymHtdqBkyLx3v/3LTQHtHJQKKHZ0YXMQS6sSM2BcrKMqbHTotUOw4GrthzWfr//
@@ -192,27 +181,21 @@ class test(testing.TestCase):
                 fyhZkYI=''')
 
     def test_nurbs0(self):
-        err, cons, args = main(mode=NURBS(nrefine=0))
+        err, args = main(mode=NURBS(nrefine=0))
         with self.subTest('l2-error'):
             self.assertAlmostEqual(err[0], .00200, places=5)
         with self.subTest('h1-error'):
             self.assertAlmostEqual(err[1], .02271, places=5)
-        with self.subTest('constraints'):
-            self.assertAlmostEqual64(cons['u'], '''
-                eNpjYGBoQIIggMZXOKdmnHRe3vjh+cvGDAwA6w0LgQ==''')
         with self.subTest('left-hand side'):
             self.assertAlmostEqual64(args['u'], '''
                 eNpjYJh07qLhhnOTjb0vTDdmAAKVcy/1u85lGYforQDzFc6pGSedlzd+eP4ykA8AvkQRaA==''')
 
     def test_nurbs2(self):
-        err, cons, args = main(mode=NURBS(nrefine=2))
+        err, args = main(mode=NURBS(nrefine=2))
         with self.subTest('l2-error'):
             self.assertAlmostEqual(err[0], .00009, places=5)
         with self.subTest('h1-error'):
             self.assertAlmostEqual(err[1], .00286, places=5)
-        with self.subTest('constraints'):
-            self.assertAlmostEqual64(cons['u'], '''
-                eNpjYGBoIAKCwCBXp3kuysDjnLXR+3NPjTzPqxrnAnHeeQvjk+dTjZ9d2GG85soJYwYGAPkhPtE=''')
         with self.subTest('left-hand side'):
             self.assertAlmostEqual64(args['u'], '''
                 eNpjYOg890mv85yM4axz0kYHz+00Yj6vZJxzPtWY+0KPMffFucaml+caMwBB5LlCvYhzCw0qzu0wPHyu


### PR DESCRIPTION
This PR introduces a new way to impose constraints. Example with inhomogeneous Dirichlet boundary condition, old style (remains valid):

```python
ns.add_field(('u', 'v'), basis)
ns.f = ...
res = ...
sqr = domain.boundary.integral('(u - f)^2 dS' @ ns, degree=...)
cons = solver.optimze('u,', sqr, droptol=...)
args = solver.solve_linear('u:v', res, constrain=cons)
```

New style:

```python
ns.add_field(('u', 'v', 'w'), basis)
ns.f = ...
res = ...
res += domain.boundary.integral('w (u - f) dS' @ ns, degree=...)
args = solver.solve_linear('u:v:w', res)
```

The new field `w` serves as 'test' function for the constraints and the constraint now has the form of a projection.

In addition it is possible to apply asymmetric constraints. Continuing the above example: Boundary value `f` is the result of another problem with test space `g`, which depends on `u`. This can be achieved by the constraint

```python
res = += domain.boundary.integral('(w (u - f) + w v) dS', degree=...)
args = solver.solve_linear('u:v:w*,f:g', res)
```

In addition to the constraint `w (u - f)` we also add `w v`, which explicitly constrains the test space. To signal that we have asymmetric constraints, the constraint argument `w` has a star in the targets passed to `solve_linear`.