### PR TITLE
no implicit type casting

### DIFF
--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -62,9 +62,9 @@ def simplified(value: 'Evaluable'):
     return value.simplified
 
 
-_type_order = bool, int, float, complex
-asdtype = lambda arg: arg if any(arg is dtype for dtype in _type_order) else {'f': float, 'i': int, 'b': bool, 'c': complex}[numpy.dtype(arg).kind]
-Dtype = typing.Union[_type_order]
+_array_dtypes = bool, int, float, complex
+asdtype = lambda arg: arg if any(arg is dtype for dtype in _array_dtypes) else {'f': float, 'i': int, 'b': bool, 'c': complex}[numpy.dtype(arg).kind]
+Dtype = typing.Union[_array_dtypes]
 
 
 def asarray(arg):
@@ -838,7 +838,7 @@ class Array(Evaluable, metaclass=_ArrayMeta):
 
     def __init__(self, args, shape: typing.Tuple['Array', ...], dtype: Dtype):
         assert isinstance(shape, tuple) and all(_isindex(n) for n in shape), f'shape={shape!r}'
-        assert isinstance(dtype, type) and dtype in _type_order, f'dtype={dtype!r}'
+        assert isinstance(dtype, type) and dtype in _array_dtypes, f'dtype={dtype!r}'
         self.shape = shape
         self.dtype = dtype
         super().__init__(args=args)

--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -637,9 +637,6 @@ def conjugate(arg):
         return arg
 
 
-conjugate
-
-
 def real(arg):
     arg = asarray(arg)
     if arg.dtype == complex:

--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -4626,11 +4626,6 @@ def _numpy_align(a, b):
 
     a = asarray(a)
     b = asarray(b)
-    if a.dtype != b.dtype:
-        if _type_order.index(a.dtype) < _type_order.index(b.dtype):
-            a = astype(a, b.dtype)
-        else:
-            b = astype(b, a.dtype)
     if not a.ndim:
         return _inflate_scalar(a, b.shape), b
     if not b.ndim:

--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -1062,8 +1062,8 @@ class Orthonormal(Array):
     'make a vector orthonormal to a subspace'
 
     def __init__(self, basis: Array, vector: Array):
-        assert isinstance(basis, Array) and basis.ndim >= 2 and basis.dtype != complex, f'basis={basis!r}'
-        assert isinstance(vector, Array) and vector.ndim >= 1 and vector.dtype != complex, f'vector={vector!r}'
+        assert isinstance(basis, Array) and basis.ndim >= 2 and basis.dtype not in (bool, complex), f'basis={basis!r}'
+        assert isinstance(vector, Array) and vector.ndim >= 1 and vector.dtype not in (bool, complex), f'vector={vector!r}'
         assert equalshape(basis.shape[:-1], vector.shape)
         self._basis = basis
         self._vector = vector

--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -626,6 +626,9 @@ def dot(a, b, axes):
     Contract ``a`` and ``b`` along ``axes``.
     '''
 
+    a, b = _numpy_align(a, b)
+    if a.dtype == bool or b.dtype == bool:
+        raise ValueError('The boolean dot product is not supported.')
     return multiply(a, b).sum(axes)
 
 

--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -1587,7 +1587,7 @@ class Inverse(Array):
     '''
 
     def __init__(self, func: Array):
-        assert isinstance(func, Array) and func.ndim >= 2 and _equals_simplified(func.shape[-1], func.shape[-2]), f'func={func!r}'
+        assert isinstance(func, Array) and func.dtype != bool and func.ndim >= 2 and _equals_simplified(func.shape[-1], func.shape[-2]), f'func={func!r}'
         self.func = func
         super().__init__(args=(func,), shape=func.shape, dtype=complex if func.dtype == complex else float)
 
@@ -4852,6 +4852,9 @@ def sqrt_abs_det_gram(arg, axes=(-2, -1)):
 
 
 def inverse(arg, axes=(-2, -1)):
+    arg = asarray(arg)
+    if arg.dtype == bool:
+        raise ValueError('The boolean inverse is not supported.')
     return Transpose.from_end(Inverse(Transpose.to_end(arg, *axes)), *axes)
 
 

--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -1628,7 +1628,7 @@ class Inverse(Array):
 class Determinant(Array):
 
     def __init__(self, func: Array):
-        assert isarray(func) and func.ndim >= 2 and _equals_simplified(func.shape[-1], func.shape[-2])
+        assert isarray(func) and func.dtype != bool and func.ndim >= 2 and _equals_simplified(func.shape[-1], func.shape[-2])
         self.func = func
         super().__init__(args=(func,), shape=func.shape[:-2], dtype=complex if func.dtype == complex else float)
 
@@ -4834,6 +4834,9 @@ def get(arg, iax, item):
 
 
 def determinant(arg, axes=(-2, -1)):
+    arg = asarray(arg)
+    if arg.dtype == bool:
+        raise ValueError('The boolean determinant is not supported.')
     return Determinant(Transpose.to_end(arg, *axes))
 
 

--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -2679,12 +2679,14 @@ class FloatToComplex(Cast):
 
 def astype(arg, dtype):
     arg = asarray(arg)
-    i = _type_order.index(arg.dtype)
-    j = _type_order.index(dtype)
-    if i > j:
+    if arg.dtype == bool and dtype != bool:
+        arg = BoolToInt(arg)
+    if arg.dtype == int and dtype != int:
+        arg = IntToFloat(arg)
+    if arg.dtype == float and dtype != float:
+        arg = FloatToComplex(arg)
+    if arg.dtype != dtype:
         raise TypeError('Downcasting is forbidden.')
-    for cast in (BoolToInt, IntToFloat, FloatToComplex)[i:j]:
-        arg = cast(arg)
     return arg
 
 

--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -2117,7 +2117,7 @@ class Take(Array):
 class Power(Array):
 
     def __init__(self, func: Array, power: Array):
-        assert isinstance(func, Array), f'func={func!r}'
+        assert isinstance(func, Array) and func.dtype != bool, f'func={func!r}'
         assert isinstance(power, Array) and (power.dtype in (float, complex) or power.dtype == int and power._intbounds[0] >= 0), f'power={power!r}'
         assert equalshape(func.shape, power.shape) and func.dtype == power.dtype, 'Power({}, {})'.format(func, power)
         self.func = func

--- a/nutils/sample.py
+++ b/nutils/sample.py
@@ -917,8 +917,8 @@ class _Integral(function.Array):
 
     def lower(self, args: function.LowerArgs) -> evaluable.Array:
         ielem = evaluable.loop_index('_sample_' + '_'.join(self._sample.spaces), self._sample.nelems)
-        weights = self._sample.get_evaluable_weights(ielem)
-        integrand = self._integrand.lower(args | self._sample.get_lower_args(ielem))
+        weights = evaluable.astype(self._sample.get_evaluable_weights(ielem), self.dtype)
+        integrand = evaluable.astype(self._integrand.lower(args | self._sample.get_lower_args(ielem)), self.dtype)
         elem_integral = evaluable.einsum('B,ABC->AC', weights, integrand, B=weights.ndim, C=self.ndim)
         return evaluable.loop_sum(elem_integral, ielem)
 

--- a/nutils/solver.py
+++ b/nutils/solver.py
@@ -644,7 +644,7 @@ class _thetamethod(cache.Recursion, length=1, version=1):
         self.old_new.append((timetarget+historysuffix, timetarget))
         subs0 = {new: evaluable.Argument(old, tuple(map(evaluable.constant, self.lhs0[new].shape))) for old, new in self.old_new}
         dt = evaluable.Argument(timetarget, ()) - subs0[timetarget]
-        self.residuals = tuple(res * theta + evaluable.replace_arguments(res, subs0) * (1-theta) + (inert - evaluable.replace_arguments(inert, subs0)) / dt for res, inert in zip(residual, inertia))
+        self.residuals = tuple(res * evaluable.astype(theta, res.dtype) + evaluable.replace_arguments(res, subs0) * evaluable.astype(1-theta, res.dtype) + (inert - evaluable.replace_arguments(inert, subs0)) / evaluable.astype(dt, res.dtype) for res, inert in zip(residual, inertia))
         self.jacobians = _derivative(self.residuals, target)
 
     def _step(self, lhs0, dt):

--- a/tests/test_evaluable.py
+++ b/tests/test_evaluable.py
@@ -158,6 +158,8 @@ class check(TestCase):
                                            actual=evaluable.inverse(self.actual, axes=(ax1, ax2)))
 
     def test_determinant(self):
+        if self.actual.dtype == bool:
+            return
         for ax1, ax2 in self.pairs:
             self.assertFunctionAlmostEqual(decimal=11,
                                            desired=numpy.linalg.det(self.desired.transpose([i for i in range(self.desired.ndim) if i not in (ax1, ax2)] + [ax1, ax2])),


### PR DESCRIPTION
Many of the evaluable array ops (the functions, not the classes) support automatic type casting. For example you can do `evaluable.add(1, 1.5)` without problems. However, you can also do `evaluable.add(True, 1)` (evaluates to 2, int), and here implicit casting makes less sense. To prevent unforeseen casts, this PR disallows all implicit casting in evaluable array ops.