### PR TITLE
boolean operators

### DIFF
--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -897,6 +897,7 @@ class Array(Evaluable, metaclass=_ArrayMeta):
     __mod__ = lambda self, other: mod(self, other)
     __int__ = __index__
     __str__ = __repr__ = lambda self: '{}.{}<{}>'.format(type(self).__module__, type(self).__name__, self._shape_str(form=str))
+    __inv__ = lambda self: LogicalNot(self) if self.dtype == bool else NotImplemented
 
     def _shape_str(self, form):
         dtype = self.dtype.__name__[0] if hasattr(self, 'dtype') else '?'
@@ -2488,6 +2489,20 @@ class Less(Pointwise):
         elif T1 == bool:
             raise ValueError('Use logical operators to compare booleans.')
         return bool
+
+
+class LogicalNot(Pointwise):
+    evalf = staticmethod(numpy.logical_not)
+    def return_type(T):
+        if T != bool:
+            raise ValueError(f'Expected a boolean but got {T}.')
+        return bool
+
+    def _simplified(self):
+        arg, = self.args
+        if isinstance(arg, LogicalNot):
+            return arg.args[0]
+        return super()._simplified()
 
 
 class Minimum(Pointwise):

--- a/nutils/function.py
+++ b/nutils/function.py
@@ -3045,6 +3045,56 @@ class __implementations__:
             raise ValueError('Complex numbers have no total order.')
         return _Wrapper.broadcasted_arrays(evaluable.Maximum, a, b)
 
+    @implements(numpy.logical_and)
+    @implements(numpy.bitwise_and)
+    def logical_and(a: IntoArray, b: IntoArray) -> Array:
+        a, b = map(Array.cast, (a, b))
+        if a.dtype != bool or b.dtype != bool:
+            return NotImplemented
+        return _Wrapper.broadcasted_arrays(evaluable.multiply, a, b)
+
+    @implements(numpy.logical_or)
+    @implements(numpy.bitwise_or)
+    def logical_or(a: IntoArray, b: IntoArray) -> Array:
+        a, b = map(Array.cast, (a, b))
+        if a.dtype != bool or b.dtype != bool:
+            return NotImplemented
+        return _Wrapper.broadcasted_arrays(evaluable.add, a, b)
+
+    @implements(numpy.logical_not)
+    @implements(numpy.invert)
+    def logical_not(a: IntoArray) -> Array:
+        a = Array.cast(a)
+        if a.dtype != bool:
+            return NotImplemented
+        return _Wrapper.broadcasted_arrays(evaluable.LogicalNot, a, force_dtype=bool)
+
+    @implements(numpy.all)
+    def all(a: IntoArray, axis = None) -> Array:
+        a = Array.cast(a)
+        if a.dtype != bool:
+            return NotImplemented
+        if axis is None:
+            a = numpy.ravel(a)
+        elif isinstance(axis, int):
+            a = _Transpose.to_end(a, axis)
+        else:
+            return NotImplemented
+        return _Wrapper(evaluable.Product, a, shape=a.shape[:-1], dtype=bool)
+
+    @implements(numpy.any)
+    def any(a: IntoArray, axis = None) -> Array:
+        a = Array.cast(a)
+        if a.dtype != bool:
+            return NotImplemented
+        if axis is None:
+            a = numpy.ravel(a)
+        elif isinstance(axis, int):
+            a = _Transpose.to_end(a, axis)
+        else:
+            return NotImplemented
+        return _Wrapper(evaluable.Sum, a, shape=a.shape[:-1], dtype=bool)
+
     @implements(numpy.sum)
     def sum(arg: IntoArray, axis: Optional[Union[int, Sequence[int]]] = None) -> Array:
         arg = Array.cast(arg)

--- a/tests/test_evaluable.py
+++ b/tests/test_evaluable.py
@@ -235,7 +235,7 @@ class check(TestCase):
             return
         for iax in range(self.actual.ndim):
             self.assertFunctionAlmostEqual(decimal=14,
-                                           desired=numpy.product(self.desired, axis=iax),
+                                           desired=(numpy.all if self.actual.dtype == bool else numpy.prod)(self.desired, axis=iax),
                                            actual=evaluable.product(self.actual, axis=iax))
 
     def test_getslice(self):
@@ -561,6 +561,7 @@ _check('greater', evaluable.Greater, numpy.greater, ANY(4, 4), ANY(4, 4), zerogr
 _check('less', evaluable.Less, numpy.less, ANY(4, 4), ANY(4, 4), zerograd=True)
 _check('logical_not', evaluable.LogicalNot, numpy.logical_not, numpy.array([[False, False], [True, True], [False, True]], dtype=bool))
 _check('logical_any', evaluable.Sum, lambda a: numpy.any(a, axis=-1), numpy.array([[False, False], [True, True], [False, True]], dtype=bool))
+_check('logical_all', evaluable.Product, lambda a: numpy.all(a, axis=-1), numpy.array([[False, False], [True, True], [False, True]], dtype=bool))
 _check('arctan2', evaluable.arctan2, numpy.arctan2, ANY(4, 4), ANY(4, 4))
 _check('stack', lambda a, b: evaluable.stack([a, b], 0), lambda a, b: numpy.concatenate([a[numpy.newaxis, :], b[numpy.newaxis, :]], axis=0), ANY(4), ANY(4))
 _check('eig', lambda a: evaluable.eig(a+a.swapaxes(0, 1), symmetric=True)[1], lambda a: numpy.linalg.eigh(a+a.swapaxes(0, 1))[1], ANY(4, 4), hasgrad=False)

--- a/tests/test_evaluable.py
+++ b/tests/test_evaluable.py
@@ -254,15 +254,11 @@ class check(TestCase):
                                            actual=self.actual.sum(idim))
 
     def test_add(self):
-        if self.actual.dtype == bool:
-            return
         self.assertFunctionAlmostEqual(decimal=14,
                                        desired=self.desired + self.other,
                                        actual=(self.actual + self.other))
 
     def test_multiply(self):
-        if self.actual.dtype == bool:
-            return
         self.assertFunctionAlmostEqual(decimal=14,
                                        desired=self.desired * self.other,
                                        actual=(self.actual * self.other))
@@ -559,6 +555,8 @@ _check('max', lambda a, b: evaluable.Maximum(a, b), numpy.maximum, ANY(4, 4), AN
 _check('equal', evaluable.Equal, numpy.equal, ANY(4, 4), ANY(4, 4), zerograd=True)
 _check('greater', evaluable.Greater, numpy.greater, ANY(4, 4), ANY(4, 4), zerograd=True)
 _check('less', evaluable.Less, numpy.less, ANY(4, 4), ANY(4, 4), zerograd=True)
+_check('logical_and', evaluable.multiply, numpy.logical_and, numpy.array([[False, False], [True, True]], dtype=bool), numpy.array([[False, True], [False, True]], dtype=bool))
+_check('logical_or', evaluable.add, numpy.logical_or, numpy.array([[False, False], [True, True], [False, True]], dtype=bool), numpy.array([[False, True], [False, True], [True, False]], dtype=bool))
 _check('logical_not', evaluable.LogicalNot, numpy.logical_not, numpy.array([[False, False], [True, True], [False, True]], dtype=bool))
 _check('logical_any', evaluable.Sum, lambda a: numpy.any(a, axis=-1), numpy.array([[False, False], [True, True], [False, True]], dtype=bool))
 _check('logical_all', evaluable.Product, lambda a: numpy.all(a, axis=-1), numpy.array([[False, False], [True, True], [False, True]], dtype=bool))
@@ -1054,6 +1052,14 @@ class simplify(TestCase):
     def test_double_logical_not(self):
         a = evaluable.Argument('test', shape=(), dtype=bool)
         self.assertEqual(evaluable.LogicalNot(evaluable.LogicalNot(a)).simplified, a)
+
+    def test_logical_or_same_args(self):
+        a = evaluable.Argument('test', shape=(), dtype=bool)
+        self.assertEqual((a | a).simplified, a)
+
+    def test_logical_and_same_args(self):
+        a = evaluable.Argument('test', shape=(), dtype=bool)
+        self.assertEqual((a & a).simplified, a)
 
 
 class memory(TestCase):

--- a/tests/test_evaluable.py
+++ b/tests/test_evaluable.py
@@ -248,11 +248,9 @@ class check(TestCase):
                                            actual=self.actual[s])
 
     def test_sumaxis(self):
-        if self.desired.dtype == bool:
-            return
         for idim in range(self.actual.ndim):
             self.assertFunctionAlmostEqual(decimal=14,
-                                           desired=self.desired.sum(idim),
+                                           desired=(numpy.any if self.actual.dtype == bool else numpy.sum)(self.desired, axis=idim),
                                            actual=self.actual.sum(idim))
 
     def test_add(self):
@@ -562,6 +560,7 @@ _check('equal', evaluable.Equal, numpy.equal, ANY(4, 4), ANY(4, 4), zerograd=Tru
 _check('greater', evaluable.Greater, numpy.greater, ANY(4, 4), ANY(4, 4), zerograd=True)
 _check('less', evaluable.Less, numpy.less, ANY(4, 4), ANY(4, 4), zerograd=True)
 _check('logical_not', evaluable.LogicalNot, numpy.logical_not, numpy.array([[False, False], [True, True], [False, True]], dtype=bool))
+_check('logical_any', evaluable.Sum, lambda a: numpy.any(a, axis=-1), numpy.array([[False, False], [True, True], [False, True]], dtype=bool))
 _check('arctan2', evaluable.arctan2, numpy.arctan2, ANY(4, 4), ANY(4, 4))
 _check('stack', lambda a, b: evaluable.stack([a, b], 0), lambda a, b: numpy.concatenate([a[numpy.newaxis, :], b[numpy.newaxis, :]], axis=0), ANY(4), ANY(4))
 _check('eig', lambda a: evaluable.eig(a+a.swapaxes(0, 1), symmetric=True)[1], lambda a: numpy.linalg.eigh(a+a.swapaxes(0, 1))[1], ANY(4, 4), hasgrad=False)
@@ -1358,7 +1357,7 @@ class log_error(TestCase):
   %0 = EVALARGS --> dict
   %1 = nutils.evaluable.Constant<f:> --> ndarray<f:>
   %2 = nutils.evaluable.Constant<f:2> --> ndarray<f:2>
-  %3 = nutils.evaluable.Sum<f:> arr=%2 --> float64
+  %3 = nutils.evaluable.Sum<f:> a=%2 --> float64
   %4 = nutils.evaluable.Add<f:> %1 %3 --> float64
   %5 = tests.test_evaluable.Fail<i:> arg1=%4 arg2=%1 --> operation failed intentially.''')
 

--- a/tests/test_evaluable.py
+++ b/tests/test_evaluable.py
@@ -561,6 +561,7 @@ _check('max', lambda a, b: evaluable.Maximum(a, b), numpy.maximum, ANY(4, 4), AN
 _check('equal', evaluable.Equal, numpy.equal, ANY(4, 4), ANY(4, 4), zerograd=True)
 _check('greater', evaluable.Greater, numpy.greater, ANY(4, 4), ANY(4, 4), zerograd=True)
 _check('less', evaluable.Less, numpy.less, ANY(4, 4), ANY(4, 4), zerograd=True)
+_check('logical_not', evaluable.LogicalNot, numpy.logical_not, numpy.array([[False, False], [True, True], [False, True]], dtype=bool))
 _check('arctan2', evaluable.arctan2, numpy.arctan2, ANY(4, 4), ANY(4, 4))
 _check('stack', lambda a, b: evaluable.stack([a, b], 0), lambda a, b: numpy.concatenate([a[numpy.newaxis, :], b[numpy.newaxis, :]], axis=0), ANY(4), ANY(4))
 _check('eig', lambda a: evaluable.eig(a+a.swapaxes(0, 1), symmetric=True)[1], lambda a: numpy.linalg.eigh(a+a.swapaxes(0, 1))[1], ANY(4, 4), hasgrad=False)
@@ -1049,6 +1050,10 @@ class simplify(TestCase):
         inflated = evaluable.Inflate(a, dofmap=evaluable.constant([2,0]), length=evaluable.constant(3))
         taken = evaluable.Take(inflated, indices=evaluable.constant([1]))
         self.assertTrue(evaluable.iszero(taken))
+
+    def test_double_logical_not(self):
+        a = evaluable.Argument('test', shape=(), dtype=bool)
+        self.assertEqual(evaluable.LogicalNot(evaluable.LogicalNot(a)).simplified, a)
 
 
 class memory(TestCase):

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -323,6 +323,17 @@ _check('min', lambda a, b: numpy.minimum(a, function.Array.cast(b)), numpy.minim
 _check('max', lambda a, b: numpy.maximum(a, function.Array.cast(b)), numpy.maximum, ANY(4, 1), ANY(1, 4))
 _check('heaviside', function.heaviside, lambda u: numpy.heaviside(u, .5), ANY(4, 4))
 
+_check('logical_and', lambda a, b: numpy.logical_and(a, function.Array.cast(b)), numpy.logical_and, numpy.array([False, True, True])[:,None], numpy.array([True, False])[None,:])
+_check('bitwise_and-bool', lambda a, b: numpy.bitwise_and(a, function.Array.cast(b)), numpy.bitwise_and, numpy.array([False, True, True])[:,None], numpy.array([True, False])[None,:])
+_check('logical_or', lambda a, b: numpy.logical_or(a, function.Array.cast(b)), numpy.logical_or, numpy.array([False, True, True])[:,None], numpy.array([True, False])[None,:])
+_check('bitwise_or-bool', lambda a, b: numpy.bitwise_or(a, function.Array.cast(b)), numpy.bitwise_or, numpy.array([False, True, True])[:,None], numpy.array([True, False])[None,:])
+_check('logical_not', lambda a: numpy.logical_not(function.Array.cast(a)), numpy.logical_not, numpy.array([[False, True], [True, False], [True, True]]))
+_check('invert-bool', lambda a: numpy.invert(function.Array.cast(a)), numpy.invert, numpy.array([[False, True], [True, False], [True, True]]))
+_check('all-bool-all-axes', lambda a: numpy.all(function.Array.cast(a)), numpy.all, numpy.array([[False, True], [True, True]]))
+_check('all-bool-single-axis', lambda a: numpy.all(function.Array.cast(a), axis=0), lambda a: numpy.all(a, axis=0), numpy.array([[False, True], [True, True]]))
+_check('any-bool-all-axes', lambda a: numpy.any(function.Array.cast(a)), numpy.any, numpy.array([[False, True], [True, True]]))
+_check('any-bool-single-axis', lambda a: numpy.any(function.Array.cast(a), axis=0), lambda a: numpy.any(a, axis=0), numpy.array([[False, True], [False, False]]))
+
 ## TODO: opposite
 ## TODO: mean
 ## TODO: jump


### PR DESCRIPTION
This PR adds support for the boolean operators not, and, or, all and any to `evaluable.Array` and `function.Array`.