### PR TITLE
remove evaluable.Points,NPoints,Weights

### DIFF
--- a/nutils/element.py
+++ b/nutils/element.py
@@ -282,7 +282,7 @@ class Reference(types.Singleton):
         if len(ctransforms) == 1:
             ctrans, = ctransforms
             assert not ctrans
-            return ((), self.getpoints('vertex', maxrefine), allindices),
+            return ((), maxrefine, allindices),
         if maxrefine == 0:
             raise Exception('maxrefine is too low')
         cbins = [set() for ichild in range(self.nchildren)]
@@ -292,9 +292,9 @@ class Reference(types.Singleton):
         if not all(cbins):
             raise Exception('transformations to not form an element cover')
         fcache = cache.WrapperCache()
-        return tuple(((ctrans,) + trans, points, cindices[indices])
+        return tuple(((ctrans,) + trans, degree, cindices[indices])
                      for ctrans, cref, cbin, cindices in zip(self.child_transforms, self.child_refs, cbins, self.child_divide(allindices, maxrefine))
-                     for trans, points, indices in fcache[cref._linear_cover](frozenset(cbin), maxrefine-1))
+                     for trans, degree, indices in fcache[cref._linear_cover](frozenset(cbin), maxrefine-1))
 
     def __str__(self):
         return self.__class__.__name__

--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -1024,43 +1024,6 @@ class Array(Evaluable, metaclass=_ArrayMeta):
             return lower if lower == upper else None
 
 
-class NPoints(Array):
-    'The length of the points axis.'
-
-    def __init__(self):
-        super().__init__(args=(EVALARGS,), shape=(), dtype=int)
-
-    @staticmethod
-    def evalf(evalargs):
-        points = evalargs['_points'].coords
-        return types.frozenarray(points.shape[0])
-
-    def _intbounds_impl(self):
-        return 0, float('inf')
-
-
-class Points(Array):
-
-    def __init__(self, npoints, ndim):
-        super().__init__(args=(EVALARGS,), shape=(npoints, ndim), dtype=float)
-
-    @staticmethod
-    def evalf(evalargs):
-        return evalargs['_points'].coords
-
-
-class Weights(Array):
-
-    def __init__(self, npoints):
-        super().__init__(args=(EVALARGS,), shape=(npoints,), dtype=float)
-
-    @staticmethod
-    def evalf(evalargs):
-        weights = evalargs['_points'].weights
-        assert numeric.isarray(weights) and weights.ndim == 1
-        return weights
-
-
 class Orthonormal(Array):
     'make a vector orthonormal to a subspace'
 

--- a/tests/test_evaluable.py
+++ b/tests/test_evaluable.py
@@ -755,9 +755,6 @@ class intbounds(TestCase):
     def test_inrange_empty(self):
         self.assertEqual(evaluable.InRange(self.S('n', float('-inf'), float('inf')), evaluable.constant(0))._intbounds, (0, 0))
 
-    def test_npoints(self):
-        self.assertEqual(evaluable.NPoints()._intbounds, (0, float('inf')))
-
     def test_bool_to_int(self):
         self.assertEqual(evaluable.BoolToInt(evaluable.constant(numpy.array([False, True], dtype=bool)))._intbounds, (0, 1))
 

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -649,9 +649,9 @@ class TopologyAssertions:
         interfaces = domain.interfaces
         bmask = numpy.zeros(len(boundary), dtype=int)
         imask = numpy.zeros(len(interfaces), dtype=int)
-        coordinates = evaluable.Points(evaluable.NPoints(), evaluable.constant(boundary.ndims))
         edges = domain.transforms.edges(domain.references)
         iedge = evaluable.Argument('_iedge', (), int)
+        coordinates = domain.references.edges.getpoints('gauss', 2).get_evaluable_coords(iedge)
         lowered_geom = geom.lower(function.LowerArgs.for_space(domain.space, (edges,), iedge, coordinates)).simplified
         for ielem, ioppelems in enumerate(domain.connectivity):
             for iedge, ioppelem in enumerate(ioppelems):
@@ -673,9 +673,8 @@ class TopologyAssertions:
                         self.assertEqual(interfaces.opposites[index], opptrans)
                     imask[index] += 1
                     self.assertEqual(eref, opperef)
-                    points = eref.getpoints('gauss', 2)
-                    a0 = lowered_geom.eval(_iedge=edges.index(trans), _points=points)
-                    a1 = lowered_geom.eval(_iedge=edges.index(opptrans), _points=points)
+                    a0 = lowered_geom.eval(_iedge=edges.index(trans))
+                    a1 = lowered_geom.eval(_iedge=edges.index(opptrans))
                     numpy.testing.assert_array_almost_equal(a0, a1)
         self.assertTrue(numpy.equal(bmask, 1).all())
         self.assertTrue(numpy.equal(imask, 2).all())


### PR DESCRIPTION
In an effort to make the `evaluable` module array-only (#738), this PR replaces and removes the `evaluable.Points`, `.NPoints` and `.Weights` classes.