### PR TITLE
eliminate and remove EvaluableConstant

### DIFF
--- a/nutils/evaluable.py
+++ b/nutils/evaluable.py
@@ -521,32 +521,6 @@ class EVALARGS(Evaluable):
 EVALARGS = EVALARGS()
 
 
-class EvaluableConstant(Evaluable):
-    '''Evaluate to the given constant value.
-
-    Parameters
-    ----------
-    value
-        The return value of ``eval``.
-    '''
-
-    def __init__(self, value):
-        self.value = value
-        super().__init__(())
-
-    def evalf(self):
-        return self.value
-
-    @property
-    def _node_details(self):
-        s = repr(self.value)
-        if '\n' in s:
-            s = s.split('\n', 1)[0] + '...'
-        if len(s) > 20:
-            s = s[:17] + '...'
-        return s
-
-
 class Tuple(Evaluable):
 
     def __init__(self, items):

--- a/tests/test_evaluable.py
+++ b/tests/test_evaluable.py
@@ -1146,27 +1146,6 @@ class combine_loop_concatenates(TestCase):
         self.assertEqual(actual, desired)
 
 
-class EvaluableConstant(TestCase):
-
-    def test_evalf(self):
-        self.assertEqual(evaluable.EvaluableConstant(1).evalf(), 1)
-        self.assertEqual(evaluable.EvaluableConstant('1').evalf(), '1')
-
-    def test_node_details(self):
-
-        class Test:
-            def __init__(self, s):
-                self.s = s
-
-            def __repr__(self):
-                return self.s
-
-        self.assertEqual(evaluable.EvaluableConstant(Test('some string'))._node_details, 'some string')
-        self.assertEqual(evaluable.EvaluableConstant(Test('a very long string that should be abbreviated'))._node_details, 'a very long strin...')
-        self.assertEqual(evaluable.EvaluableConstant(Test('a string with\nmultiple lines'))._node_details, 'a string with...')
-        self.assertEqual(evaluable.EvaluableConstant(Test('a very long string with\nmultiple lines'))._node_details, 'a very long strin...')
-
-
 class Einsum(TestCase):
 
     def test_swapaxes(self):


### PR DESCRIPTION
In an effort to make the `evaluable` module array-only (#738), this PR eliminates and removes the `evaluable.EvaluableConstant` class.