### PR TITLE
fix SI handling of special binary methods

### DIFF
--- a/nutils/SI.py
+++ b/nutils/SI.py
@@ -372,13 +372,13 @@ class Quantity(metaclass=Dimension):
         return (dim0**args[1]).wrap(op(arg0, *args[1:], **kwargs))
 
     @register('isfinite', 'isnan', 'shape', 'ndim', 'size', 'normal', 'normalized')
-    def __unary_drop(op, *args, **kwargs):
+    def __unary_op(op, *args, **kwargs):
         (_dim0, arg0), = Quantity.__unpack(args[0])
         return op(arg0, *args[1:], **kwargs)
 
     @register('lt', 'le', 'eq', 'ne', 'gt', 'ge', 'equal', 'not_equal', 'less',
               'less_equal', 'greater', 'greater_equal')
-    def __binary_drop(op, *args, **kwargs):
+    def __binary_op(op, *args, **kwargs):
         (dim0, arg0), (dim1, arg1) = Quantity.__unpack(args[0], args[1])
         if dim0 != dim1:
             raise TypeError(f'incompatible arguments for {op.__name__}: {dim0.__name__}, {dim1.__name__}')

--- a/nutils/_util.py
+++ b/nutils/_util.py
@@ -455,7 +455,7 @@ def log_arguments(f):
         with treelog.context('arguments'):
             for k, v in bound.arguments.items():
                 try:
-                    s = stringly.dumps(sig.parameters[k].annotation, v)
+                    s = stringly.dumps(_infer_type(sig.parameters[k]), v)
                 except:
                     s = str(v)
                 treelog.info(f'{k}={s}')
@@ -630,6 +630,16 @@ def add_htmllog(outrootdir: str = '~/public_html', outrooturi: str = '', scriptn
             treelog.info(f'log written to: {loguri}')
 
 
+def _infer_type(param):
+    '''Infer argument type from annotation or default value.'''
+
+    if param.annotation is not param.empty:
+        return param.annotation
+    if param.default is not param.empty:
+        return type(param.default)
+    raise Exception(f'cannot determine type for argument {param.name!r}')
+
+
 def cli(f, *, argv=None):
     '''Call a function using command line arguments.'''
 
@@ -642,11 +652,7 @@ def cli(f, *, argv=None):
     mandatory = set()
 
     for param in inspect.signature(f).parameters.values():
-        T = param.annotation
-        if T == param.empty and param.default != param.empty:
-            T = type(param.default)
-        if T == param.empty:
-            raise Exception(f'cannot determine type for argument {param.name!r}')
+        T = _infer_type(param)
         try:
             s = stringly.serializer.get(T)
         except Exception as e:

--- a/tests/test_SI.py
+++ b/tests/test_SI.py
@@ -68,7 +68,7 @@ class Quantity(unittest.TestCase):
         F = SI.units.N * numpy.zeros(3)
         F[0] = SI.Force('1N')
         F[1] = SI.Force('2N')
-        with self.assertRaisesRegex(TypeError, r'cannot assign \[L2\] to \[M\*L/T2\]'):
+        with self.assertRaisesRegex(SI.DimensionError, r'cannot assign \[L2\] to \[M\*L/T2\]'):
             F[2] = SI.Area('10m2')
         F[2] = SI.Force('3N')
         self.assertTrue(numpy.all(F == SI.units.N * numpy.array([1, 2, 3])))
@@ -104,18 +104,18 @@ class Quantity(unittest.TestCase):
     def test_add(self):
         self.assertEqual(SI.Mass('2kg') + SI.Mass('3kg'), SI.Mass('5kg'))
         self.assertEqual(numpy.add(SI.Mass('2kg'), SI.Mass('3kg')), SI.Mass('5kg'))
-        with self.assertRaisesRegex(TypeError, r'incompatible arguments for add: \[M\], \[L\]'):
+        with self.assertRaisesRegex(SI.DimensionError, r'incompatible arguments for add: \[M\], \[L\]'):
             SI.Mass('2kg') + SI.Length('3m')
 
     def test_sub(self):
         self.assertEqual(SI.Mass('2kg') - SI.Mass('3kg'), SI.Mass('-1kg'))
         self.assertEqual(numpy.subtract(SI.Mass('2kg'), SI.Mass('3kg')), SI.Mass('-1kg'))
-        with self.assertRaisesRegex(TypeError, r'incompatible arguments for sub: \[M\], \[L\]'):
+        with self.assertRaisesRegex(SI.DimensionError, r'incompatible arguments for sub: \[M\], \[L\]'):
             SI.Mass('2kg') - SI.Length('3m')
 
     def test_hypot(self):
         self.assertEqual(numpy.hypot(SI.Mass('3kg'), SI.Mass('4kg')), SI.Mass('5kg'))
-        with self.assertRaisesRegex(TypeError, r'incompatible arguments for hypot: \[M\], \[L\]'):
+        with self.assertRaisesRegex(SI.DimensionError, r'incompatible arguments for hypot: \[M\], \[L\]'):
             numpy.hypot(SI.Mass('3kg'), SI.Length('4m'))
 
     def test_neg(self):
@@ -224,7 +224,7 @@ class Quantity(unittest.TestCase):
         C = SI.Mass('4kg')
         D = SI.Time('5s')
         self.assertTrue(numpy.all(numpy.stack([A, B, C]) == SI.units.kg * numpy.array([2, 3, 4])))
-        with self.assertRaisesRegex(TypeError, r'incompatible arguments for stack: \[M\], \[M\], \[M\], \[T\]'):
+        with self.assertRaisesRegex(SI.DimensionError, r'incompatible arguments for stack: \[M\], \[M\], \[M\], \[T\]'):
             numpy.stack([A, B, C, D])
 
     def test_concatenate(self):
@@ -232,7 +232,7 @@ class Quantity(unittest.TestCase):
         B = SI.units.kg * numpy.array([3, 4])
         C = SI.units.s * numpy.array([5, 6])
         self.assertTrue(numpy.all(numpy.concatenate([A, B]) == SI.units.kg * numpy.array([1, 2, 3, 4])))
-        with self.assertRaisesRegex(TypeError, r'incompatible arguments for concatenate: \[M\], \[M\], \[T\]'):
+        with self.assertRaisesRegex(SI.DimensionError, r'incompatible arguments for concatenate: \[M\], \[M\], \[T\]'):
             numpy.concatenate([A, B, C])
 
     def test_format(self):

--- a/tests/test_SI.py
+++ b/tests/test_SI.py
@@ -104,13 +104,13 @@ class Quantity(unittest.TestCase):
     def test_add(self):
         self.assertEqual(SI.Mass('2kg') + SI.Mass('3kg'), SI.Mass('5kg'))
         self.assertEqual(numpy.add(SI.Mass('2kg'), SI.Mass('3kg')), SI.Mass('5kg'))
-        with self.assertRaisesRegex(SI.DimensionError, r'incompatible arguments for add: \[M\], \[L\]'):
+        with self.assertRaisesRegex(TypeError, r"unsupported operand type\(s\) for \+: '\[M\]' and '\[L\]'"):
             SI.Mass('2kg') + SI.Length('3m')
 
     def test_sub(self):
         self.assertEqual(SI.Mass('2kg') - SI.Mass('3kg'), SI.Mass('-1kg'))
         self.assertEqual(numpy.subtract(SI.Mass('2kg'), SI.Mass('3kg')), SI.Mass('-1kg'))
-        with self.assertRaisesRegex(SI.DimensionError, r'incompatible arguments for sub: \[M\], \[L\]'):
+        with self.assertRaisesRegex(TypeError, r"unsupported operand type\(s\) for \-: '\[M\]' and '\[L\]'"):
             SI.Mass('2kg') - SI.Length('3m')
 
     def test_hypot(self):


### PR DESCRIPTION
This PR fixes the way that SI handles special binary methods such as `__add__` by returning `NotImplemented` rather than raising a `TypeError`. Additionally it introduces a special `SI.DimensionError`, and fixes two minor unrelated issues.