### PR TITLE
rm function.replace, add deep and shallow variants

### DIFF
--- a/nutils/_util.py
+++ b/nutils/_util.py
@@ -778,4 +778,54 @@ def nutils_dispatch(f):
     return wrapper
 
 
+class IDDict:
+    '''Mapping from instance (is, not ==) to value. Keys need not be hashable.'''
+
+    def __init__(self):
+        self.__dict = {}
+
+    def __setitem__(self, key, value):
+        self.__dict[id(key)] = key, value
+
+    def __getitem__(self, key):
+        key_, value = self.__dict[id(key)]
+        assert key_ is key
+        return value
+
+    def get(self, key, default=None):
+        kv = self.__dict.get(id(key))
+        if kv is None:
+            return default
+        key_, value = kv
+        assert key_ is key
+        return value
+
+    def __delitem__(self, key):
+        del self.__dict[id(key)]
+
+    def __len__(self):
+        return len(self.__dict)
+
+    def keys(self):
+        return (key for key, value in self.__dict.values())
+
+    def values(self):
+        return (value for key, value in self.__dict.values())
+
+    def items(self):
+        return self.__dict.values()
+
+    def __iter__(self):
+        return self.keys()
+
+    def __contains__(self, key):
+        return self.__dict.__contains__(id(key))
+
+    def __str__(self):
+        return '{' + ', '.join(f'{k!r}: {v!r}' for k, v in self.items()) + '}'
+
+    def __repr__(self):
+        return self.__str__()
+
+
 # vim:sw=4:sts=4:et

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -394,3 +394,58 @@ class nutils_dispatch(TestCase):
     def test_notimp(self):
         notimp = self.NotImp()
         self.assertEqual(self.f(notimp, self.Ten()), (notimp, 10, 2))
+
+
+class IDDict(TestCase):
+
+    def setUp(self):
+        self.d = util.IDDict()
+        self.a, self.b = 'ab'
+        self.d[self.a] = 1
+        self.d[self.b] = 2
+
+    def test_getitem(self):
+        self.assertEqual(self.d[self.a], 1)
+        self.assertEqual(self.d[self.b], 2)
+
+    def test_setitem(self):
+        c = 'c'
+        self.d[c] = 3
+        self.assertEqual(self.d[c], 3)
+
+    def test_delitem(self):
+        del self.d[self.a]
+        self.assertNotIn(self.a, self.d)
+        self.assertIn(self.b, self.d)
+
+    def test_contains(self):
+        self.assertIn(self.a, self.d)
+        self.assertIn(self.b, self.d)
+        c = 'c'
+        self.assertNotIn('c', self.d)
+
+    def test_len(self):
+        self.assertEqual(len(self.d), 2)
+
+    def test_get(self):
+        self.assertEqual(self.d.get(self.a, 10), 1)
+        self.assertEqual(self.d.get(self.b, 10), 2)
+        self.assertEqual(self.d.get('c', 10), 10)
+
+    def test_keys(self):
+        self.assertEqual(list(self.d.keys()), ['a', 'b'])
+
+    def test_iter(self):
+        self.assertEqual(list(self.d), ['a', 'b'])
+
+    def test_values(self):
+        self.assertEqual(list(self.d.values()), [1, 2])
+
+    def test_items(self):
+        self.assertEqual(list(self.d.items()), [('a', 1), ('b', 2)])
+
+    def test_str(self):
+        self.assertEqual(str(self.d), "{'a': 1, 'b': 2}")
+
+    def test_repr(self):
+        self.assertEqual(repr(self.d), "{'a': 1, 'b': 2}")


### PR DESCRIPTION
This PR removes the general `function.replace decorator` and replaces it with the specialized `deep_replace_property` (used for `simplified` and `optimized_for_numpy`) and `shallow_replace` (used for `replace_arguments`, `_deep_flatten_constants` and `_combine_loop_concatenates`). The differences between the two constructs are as follows:

`@deep_replace_property`
- property
- intermediate values cached in object attribute
- depth first
- recursive

`@shallow_replace`
- function
- intermediate values cached only during replacement
- depth last
- non recursive