### PR TITLE
Remove psutil and bottombar dependencies

### DIFF
--- a/nutils/_util.py
+++ b/nutils/_util.py
@@ -373,7 +373,7 @@ def timeit():
     treelog.info(f'finish {te:%Y-%m-%d %H:%M:%S}, elapsed {format_timedelta(te-t0)}')
 
 
-class timer:
+class elapsed:
     '''Timer that returns elapsed seconds as string representation.'''
 
     def __init__(self):

--- a/nutils/_util.py
+++ b/nutils/_util.py
@@ -592,7 +592,7 @@ def name_of_main():
 def add_htmllog(outrootdir: str = '~/public_html', outrooturi: str = '', scriptname: str = '', outdir: str = '', outuri: str = ''):
     '''Context to add a HtmlLog to the active logger.'''
 
-    import html, base64, bottombar
+    import html, base64
 
     if not scriptname and (not outdir or outrooturi and not outuri):
         scriptname = name_of_main()
@@ -619,7 +619,14 @@ def add_htmllog(outrootdir: str = '~/public_html', outrooturi: str = '', scriptn
     with treelog.HtmlLog(outdir, title=scriptname, htmltitle=htmltitle, favicon=favicon) as htmllog:
         loguri = outuri + '/' + htmllog.filename
         try:
-            with treelog.add(htmllog), bottombar.add(loguri, label='writing log to'):
+            import bottombar
+        except ImportError:
+            treelog.info(f'writing log to: {loguri}')
+            status = contextlib.nullcontext()
+        else:
+            status = bottombar.add(loguri, label='writing log to')
+        try:
+            with treelog.add(htmllog), status:
                 yield
         except Exception as e:
             with treelog.set(htmllog):

--- a/nutils/cli.py
+++ b/nutils/cli.py
@@ -13,7 +13,7 @@ def run(f, *, argv=None):
 
     decorators = (
         util.trap_sigint(),
-        bottombar.add(util.timer(), label='runtime', right=True, refresh=1), \
+        bottombar.add(util.elapsed(), label='elapsed', right=True, refresh=1), \
         bottombar.add(util.memory(), label='memory', right=True, refresh=1), \
         util.in_context(cache.caching),
         util.in_context(parallel.maxprocs),

--- a/nutils/cli.py
+++ b/nutils/cli.py
@@ -8,25 +8,33 @@ python function based arguments specified on the command line.
 def run(f, *, argv=None):
     '''Command line interface for a single function.'''
 
-    import treelog, bottombar
+    import treelog
     from . import _util as util, matrix, parallel, cache, warnings
 
-    decorators = (
-        util.trap_sigint(),
-        bottombar.add(util.elapsed(), label='elapsed', right=True, refresh=1), \
-        bottombar.add(util.memory(), label='memory', right=True, refresh=1), \
-        util.in_context(cache.caching),
-        util.in_context(parallel.maxprocs),
-        util.in_context(matrix.backend),
-        util.in_context(util.set_stdoutlog),
-        util.in_context(util.add_htmllog),
-        util.in_context(util.log_traceback),
-        util.in_context(util.post_mortem),
+    decorators = [util.trap_sigint()]
+    for func in util.elapsed, util.memory:
+        try:
+            import bottombar
+            status = func()
+        except:
+            pass
+        else:
+            decorators.append(bottombar.add(status, label=func.__name__, right=True, refresh=1))
+    decorators.extend(util.in_context(c) for c in [
+        cache.caching,
+        parallel.maxprocs,
+        matrix.backend,
+        util.set_stdoutlog,
+        util.add_htmllog,
+        util.log_traceback,
+        util.post_mortem,
+    ])
+    decorators.extend([
         warnings.via(treelog.warning),
         util.log_version,
         util.log_arguments,
         util.timeit(),
-    )
+    ])
 
     for decorator in reversed(decorators):
         f = decorator(f)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,8 @@ authors = [
 requires-python = '>=3.8'
 dependencies = [
     "appdirs >=1,<2",
-    "bottombar >=2,<3",
     "numpy >=1.17,<3",
     "nutils-poly >=1,<2",
-    "psutil >=5,<6",
     "stringly",
     "treelog >=1,<2",
 ]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -200,8 +200,8 @@ class time(TestCase):
         self.assertEqual(cm.output[1], 'ERROR:nutils:test')
         self.assertEqual(cm.output[2][:18], 'INFO:nutils:finish')
 
-    def test_timer(self):
-        self.assertEqual(str(util.timer()), '0:00')
+    def test_elapsed(self):
+        self.assertEqual(str(util.elapsed()), '0:00')
 
 
 class in_context(TestCase):


### PR DESCRIPTION
This patch removes the psutil and bottombar modules from pyproject.toml. Having them as hard dependencies is unreasonable considering that they merely provide convenience, installing them may be nontrivial, and cli.run may not even be used.

The cli.run method and _util module are modified to gracefully deal with any missing functionality, by removing the memory status or bottom bar as a whole. When the modules are installed the old behaviour is automatically restored.