### PR TITLE
Update Readthedocs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,14 @@
+version: 2
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.13"
+sphinx:
+  configuration: docs/conf.py
+  builder: "dirhtml"
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -112,7 +112,7 @@ modindex_common_prefix = ['nutils.']
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-docs = ["Sphinx >=1.8,<9"]
+docs = ["Sphinx >=1.8,<9", "sphinx_rtd_theme >=3,<4"]
 export-mpl = ["matplotlib >=3.3,<4"]
 matrix-mkl = ["mkl"]
 matrix-scipy = ["scipy >=0.13,<2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-docs = ["Sphinx >=1.8,<8"]
+docs = ["Sphinx >=1.8,<9"]
 export-mpl = ["matplotlib >=3.3,<4"]
 matrix-mkl = ["mkl"]
 matrix-scipy = ["scipy >=0.13,<2"]

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,7 +1,0 @@
-# Don't build any extra formats
-formats: []
-python:
-  version: 3
-  pip_install: true
-  extra_requirements:
-    - docs


### PR DESCRIPTION
The configuration file format for Readthedocs has changed a long time ago. Update to [version 2].

[version 2]: https://docs.readthedocs.com/platform/stable/config-file/v2.htm